### PR TITLE
Allow for the refresh rate to be specified

### DIFF
--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -33,6 +33,7 @@ namespace SandWorm
         public int rightColumns = 0;
         public int topRows = 0;
         public int bottomRows = 0;
+        public int tickRate = 20; // In ms
         public static Rhino.UnitSystem units = Rhino.RhinoDoc.ActiveDoc.ModelUnitSystem;
         public static double unitsMultiplier;
 
@@ -62,6 +63,7 @@ namespace SandWorm
             pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
 
             pManager[0].Optional = true;
             pManager[1].Optional = true;
@@ -70,6 +72,7 @@ namespace SandWorm
             pManager[4].Optional = true;
             pManager[5].Optional = true;
             pManager[6].Optional = true;
+            pManager[7].Optional = true;
         }
 
         /// <summary>
@@ -100,6 +103,7 @@ namespace SandWorm
             DA.GetData<int>(4, ref rightColumns);
             DA.GetData<int>(5, ref topRows);
             DA.GetData<int>(6, ref bottomRows);
+            DA.GetData<int>(7, ref tickRate);
 
             switch (units.ToString())
             {
@@ -186,7 +190,11 @@ namespace SandWorm
                 DA.SetDataList(0, outputMesh);
                 DA.SetDataList(1, output); //debugging
             }
-            base.OnPingDocument().ScheduleSolution(20, new GH_Document.GH_ScheduleDelegate(ScheduleDelegate));
+
+            if (tickRate > 0) // Allow users to force manual recalculation
+            {
+                base.OnPingDocument().ScheduleSolution(tickRate, new GH_Document.GH_ScheduleDelegate(ScheduleDelegate));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Hey, thanks for all the recent updates! I'm not myself sold on whether this is a good idea (and am mindful of settings overload) but there were a couple of times when I wanted to be able to control the interval between the solution expiring. These were:

- When I first started trying out the new version I had disabled the discrete GPU (long story; trying to get an external GPU running) and as a result found the performance of GH very slow. The default 20ms interval would (somewhat) slowly update in Rhino, but the definition itself was basically un-interactive. With the main GPU running again everything was fine. But it may be worth allowing users to specify a longer interval if they are running with truly bad hardware
- Related to the above: adding downstream components that do relatively heavy computations seems to essentially add latency to interacting with the definition
- When developing a definition it can be nice to have a 'manual update' mode where the mesh only updates on a forced recalculation of the definition (the slight jumping/shifting of the geometry can be distracting)