### PR TITLE
Initial experiment with #20 

### DIFF
--- a/SandWorm/Core.cs
+++ b/SandWorm/Core.cs
@@ -41,7 +41,10 @@ namespace SandWorm
                 mesh.Vertices.AddVertices(vertices);       
             }
 
-            mesh.VertexColors.SetColors(colors.ToArray());
+            if (colors.Count > 0) // Colors only provided if the mesh style permits
+            {
+                mesh.VertexColors.SetColors(colors.ToArray()); 
+            }
             return mesh;
         }
 


### PR DESCRIPTION
This all seemed simple enough in terms of code implementation, although there is a slightly strange behavior where the setting seems to 'persist' in the output mesh. If the toggle is set before the definition is executed, the resulting mesh will either be colored or 'bare' as expected. However, changing the setting subsequently will not then change the result despite the fact the correct code path is being executed for the toggle. Is there some behavior, or interaction with the scheduler, which would explain why the output mesh 'remembers' its previous vertex colors? As far as I can tell, the lookup table definitely isn't being employed.

The change in behavior in `Core.vs` and the component file is pretty straightforward now given the only options are basically on/off. If additional color options are added it would probably benefit from a better abstraction to map between the set option and, the calculations needed to identify vertex colors.

Anyway, let me know if you think the context menu approach is useful, or if #20 should be abandoned in favour of dedicated components / a standard parameter / something else.
