### PR TITLE
Initial work on dynamic pixel sizing as part of #2

### DIFF
--- a/SandWorm/Core.cs
+++ b/SandWorm/Core.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Rhino.Geometry;
 using Rhino.Display;
 using System.Drawing;
+using System;
 
 namespace SandWorm
 {
@@ -61,6 +62,33 @@ namespace SandWorm
                 j++;
             }
             return lookupTable;
+        }
+
+        public struct PixelSize // Unfortunately no nice tuples in this version of C# :(
+        {
+            public double x;
+            public double y;
+        }
+
+        public static PixelSize getDepthPixelSpacing(double sensorHeight)
+        {
+            double kinect2FOVForX = 70.6; 
+            double kinect2FOVForY = 60.0;
+            double kinect2ResolutionForX = 512;
+            double kinect2ResolutionForY = 404;
+
+            return new PixelSize
+            {
+                x = getDepthPixelSizeInDimension(kinect2FOVForX, kinect2ResolutionForX, sensorHeight),
+                y = getDepthPixelSizeInDimension(kinect2FOVForY, kinect2ResolutionForY, sensorHeight)
+            };
+        }
+
+        private static double getDepthPixelSizeInDimension(double fovAngle, double resolution, double height)
+        {
+            double fovInRadians = (Math.PI / 180) * fovAngle;
+            double dimensionSpan = 2 * height * Math.Tan(fovInRadians / 2);
+            return dimensionSpan / resolution;
         }
     }
 }

--- a/SandWorm/Core.cs
+++ b/SandWorm/Core.cs
@@ -77,11 +77,12 @@ namespace SandWorm
             double kinect2ResolutionForX = 512;
             double kinect2ResolutionForY = 404;
 
-            return new PixelSize
+            PixelSize pixelsForHeight = new PixelSize
             {
                 x = getDepthPixelSizeInDimension(kinect2FOVForX, kinect2ResolutionForX, sensorHeight),
                 y = getDepthPixelSizeInDimension(kinect2FOVForY, kinect2ResolutionForY, sensorHeight)
             };
+            return pixelsForHeight;
         }
 
         private static double getDepthPixelSizeInDimension(double fovAngle, double resolution, double height)

--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -27,7 +27,7 @@ namespace SandWorm
         public Mesh quadMesh = new Mesh();
 
         public int waterLevel;
-        public double sensorElevation = 1060; //to do - fix hard wiring
+        public double sensorElevation = 0;
         public int leftColumns = 0;
         public int rightColumns = 0;
         public int topRows = 0;
@@ -55,6 +55,7 @@ namespace SandWorm
         /// </summary>
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
+            pManager.AddNumberParameter("SensorHeight", "SH", "The height (in document units) of the sensor above your model", GH_ParamAccess.item, sensorElevation);
             pManager.AddIntegerParameter("WaterLevel", "WL", "WaterLevel", GH_ParamAccess.item, 1000);
             pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
@@ -68,6 +69,7 @@ namespace SandWorm
             pManager[3].Optional = true;
             pManager[4].Optional = true;
             pManager[5].Optional = true;
+            pManager[6].Optional = true;
         }
 
         /// <summary>
@@ -91,12 +93,13 @@ namespace SandWorm
         /// to store data in output parameters.</param>
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            DA.GetData<int>(0, ref waterLevel);
-            DA.GetData<int>(1, ref leftColumns);
-            DA.GetData<int>(2, ref rightColumns);
-            DA.GetData<int>(3, ref topRows);
-            DA.GetData<int>(4, ref bottomRows);
-            DA.GetData<int>(5, ref tickRate);
+            DA.GetData<double>(0, ref sensorElevation);
+            DA.GetData<int>(1, ref waterLevel);
+            DA.GetData<int>(2, ref leftColumns);
+            DA.GetData<int>(3, ref rightColumns);
+            DA.GetData<int>(4, ref topRows);
+            DA.GetData<int>(5, ref bottomRows);
+            DA.GetData<int>(6, ref tickRate);
 
             switch (units.ToString())
             {
@@ -128,6 +131,7 @@ namespace SandWorm
                     unitsMultiplier = 0.0328084;
                     break;
             }
+            sensorElevation = sensorElevation / unitsMultiplier; // Standardise to mm to match sensor units
 
             Stopwatch timer = Stopwatch.StartNew(); //debugging
 
@@ -150,6 +154,7 @@ namespace SandWorm
                     outputMesh = new List<Mesh>();
                     output = new List<String>(); //debugging
                     vertexColors = new List<Color>();
+                    Core.PixelSize depthPixelSize = Core.getDepthPixelSpacing(sensorElevation);
 
                     for (int rows = topRows; rows < KinectController.depthHeight - bottomRows; rows++)
 
@@ -159,8 +164,8 @@ namespace SandWorm
 
                             int i = rows * KinectController.depthWidth + columns;
 
-                            tempPoint.X = (float)(columns * -unitsMultiplier * 3); //to do - fix arbitrary grid size of 3mm
-                            tempPoint.Y = (float)(rows * -unitsMultiplier * 3); //to do - fix arbitrary grid size of 3mm
+                            tempPoint.X = (float)(columns * -unitsMultiplier * depthPixelSize.x); //to do - fix arbitrary grid size of 3mm
+                            tempPoint.Y = (float)(rows * -unitsMultiplier * depthPixelSize.y); //to do - fix arbitrary grid size of 3mm
 
                             if (KinectController.depthFrameData[i] == 0 || KinectController.depthFrameData[i] > lookupTable.Length) //check for invalid pixels
                             {

--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -27,7 +27,7 @@ namespace SandWorm
         public Mesh quadMesh = new Mesh();
 
         public int waterLevel;
-        public double sensorElevation = 0;
+        public double sensorElevation = 1000; // Arbitrary default value (must be >0)
         public int leftColumns = 0;
         public int rightColumns = 0;
         public int topRows = 0;


### PR DESCRIPTION
I had a Grasshopper definition floating around that had a calculation to determine pixel size given sensor height (I used to help figure out a table layout). I am Kinect-less at the moment so haven't tested this properly, but the `getDepthPixelSpacing` function provides the following values which seem sensible:

```
sensor height of 1060 = x 2.931725918576969
sensor height of 1060 = y 3.0296598284208076
sensor height of 500 = x 1.3828895842344193
sensor height of 500 = y 1.429084824726796
sensor height of 2000 = x 5.531558336937677
sensor height of 2000 = y 5.716339298907184
```

Note that this also adds back a sensorHeight parameter to the component, but that seemed unavoidable. Will test/update properly tomorrow to confirm it actually works when run as part of the plugin. 