### PR TITLE
Add abstraction for managing different analysis methods

### DIFF
--- a/SandWorm/Analysis.cs
+++ b/SandWorm/Analysis.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Drawing;
+using Rhino.Display;
+using Grasshopper.Kernel;
+using System.Windows.Forms;
+
+namespace SandWorm
+{
+    public static class Analysis
+    {        
+        abstract class MeshVisualisation // For all analysis options that can be enabled
+        {
+            public string menuName { get; } // Name used in the toggle menu
+            public bool menuExclusive { get; } // Whether this can be applied indepedently of other analysis
+
+            public MeshVisualisation(string name, bool exclusive)
+            {
+                menuName = name; 
+                menuExclusive = exclusive;
+            }
+
+            public ToolStripDropDown AddToMenu(ToolStripDropDown menu)
+            {
+                if (menuExclusive)
+                {
+                    // Create separator item
+                }
+                // Append menu item
+                return menu;
+            }
+        }
+
+        abstract class MeshAnalysis : MeshVisualisation // For analysis that affects the entire mesh and is mutually exclusive
+        {
+            public bool showContours;
+            public int contourInterval;
+            public bool showWaterLevel;
+            private Color[] lookupTable;
+
+            public MeshAnalysis(string name, bool exclusive, bool contours, bool water, int sensorHeight, int interval)
+                : base(name, exclusive) 
+            {
+                showContours = contours; // Not exclusive with the mesh gradient
+                showWaterLevel = water; // Not exclusive with the mesh gradient
+                lookupTable = new Color[GetLookupTableSize(sensorHeight)];
+                contourInterval = interval;
+            }
+
+            public abstract Color GetPixelColor();
+            public abstract int GetLookupTableSize(int sensorHeight);
+            public abstract void ComputeLookupTableForAnalysis(ref Color[] lookupTable, int startIndex);
+
+            public void ComputeLookupTable(int waterLevel, int contourInterval, int sensorHeight)
+            {
+                int j = 0;
+                if (showWaterLevel) // Color all pixels below water level; pass on remaining items
+                {
+                    for (int i = waterLevel; i < lookupTable.Length; i++) 
+                    {
+                        lookupTable[i] = new ColorHSL(0.6, 0.6, 0.60 - (j * 0.02)).ToArgbColor();
+                        j++;
+                    }
+                }
+
+                ComputeLookupTableForAnalysis(ref lookupTable, j);
+
+                if (showContours) // Override earlier pixels as needed to draw contours
+                {
+                    for (int i = 0; i < lookupTable.Length; i++)
+                    {
+                        // Check if within specified contour interval
+                    }
+
+                }
+            }
+        }
+
+        class NoAnalysis : MeshAnalysis
+        {
+            public NoAnalysis(bool contours, bool water, int sensorHeight, int contourInterval) 
+                : base("No Analysis", false, contours, water, sensorHeight, contourInterval) { }
+            public override Color GetPixelColor()
+            {
+                return Color.White;
+            }
+            public override int GetLookupTableSize(int sensorHeight)
+            {
+                return 0;
+            }
+            public override void ComputeLookupTableForAnalysis(ref Color[] lookupTable, int startIndex)
+            {
+                // Do nothing? Or just return a transparent color?
+            }
+        }
+
+        class ElevationAnalysis : MeshAnalysis
+        {
+            public ElevationAnalysis(bool contours, bool water, int sensorHeight, int contourInterval) 
+                : base("Elevation Analysis", false, contours, water, sensorHeight, contourInterval) { }
+            public override Color GetPixelColor()
+            {
+                return Color.White;
+            }
+            public override int GetLookupTableSize(int sensorHeight)
+            {
+                return sensorHeight;
+            }
+
+            public override void ComputeLookupTableForAnalysis(ref Color[] lookupTable, int startIndex)
+            {
+                j = 0;
+                for (int i = startIndex; i > 0; i--) 
+                {
+                    lookupTable[i] = new ColorHSL(0.01 + (j * 0.01), 1.0, 0.5).ToArgbColor();
+                    j++;
+                }
+            }
+        }
+
+        class SlopeAnalysis : MeshAnalysis
+        {
+            public SlopeAnalysis(bool contours, bool water, int sensorHeight, int contourInterval) 
+                : base("Slope Analysis", false, contours, water, sensorHeight, contourInterval) { }
+            public override Color GetPixelColor()
+            {
+                return Color.White;
+            }
+            public override int GetLookupTableSize(int sensorHeight)
+            {
+                return 90; // Slope ranges
+            }
+            public override void ComputeLookupTableForAnalysis(ref Color[] lookupTable, int startIndex)
+            {
+                // Provide a lookup table as per a reasonable range of slope values
+            }
+        }
+        class AspectAnalysis : MeshAnalysis
+        {
+            public AspectAnalysis(bool contours, bool water, int sensorHeight, int contourInterval)
+                : base("Aspect Analysis", false, contours, water, sensorHeight, contourInterval) { }
+            public override Color GetPixelColor()
+            {
+                return Color.White;
+            }
+            public override int GetLookupTableSize(int sensorHeight)
+            {
+                return 359; // Aspect ranges
+            }
+            public override void ComputeLookupTableForAnalysis(ref Color[] lookupTable, int startIndex)
+            {
+                // Provide a lookup table as per a reasonable range of aspect values
+            }
+        }        
+    }
+}

--- a/SandWorm/Analysis.cs
+++ b/SandWorm/Analysis.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Collections.Generic;
 using Rhino.Display;
 using Rhino.Geometry;
 using Grasshopper.Kernel;
@@ -8,133 +9,246 @@ using System.Windows.Forms;
 namespace SandWorm
 {
     public static class Analysis
-    {        
-        public abstract class MeshVisualisation // For all analysis options that can be enabled
+    {
+        public static class AnalysisManager
         {
-            public string name { get; } // Name used in the toggle menu
-            public bool isExclusive { get; } // Whether this can be applied indepedently of other analysis
-            public bool isEnabled { get; set; } // Whether to apply the analysis
-            public Color[] lookupTable;
+            /// <summary>Stories copies of each analysis option and intefaces their use with components.</summary>
+            public static List<MeshVisualisation> options;
+
+            static AnalysisManager()
+            {
+                // Note their order in array determines their priority; i.e. which color 'wins'
+                // Also needs to manually arrange the exclusive options together
+                options = new List<Analysis.MeshVisualisation> {
+                    new Analysis.Water(), new Analysis.Contours(),
+                    new Analysis.None(),
+                    new Analysis.Elevation(), new Analysis.Slope(), new Analysis.Aspect(),
+                };
+                // Default to showing no analysis
+                options[2].IsEnabled = true;
+            }
+
+            public static void SetEnabledOptions(ToolStripMenuItem selectedMenuItem)
+            {
+                MeshVisualisation selectedOption = options.Find(x => x.MenuItem == selectedMenuItem);
+                if (selectedOption.IsExclusive)
+                    foreach (MeshVisualisation option in AnalysisManager.options)
+                        option.IsEnabled = selectedOption == option; // Tick a toggle on or off
+                else
+                    selectedOption.IsEnabled = !selectedOption.IsEnabled; // Simple toggle for independent items
+            }
+
+            private static List<MeshVisualisation> GetEnabledOptions()
+            {
+                return options.FindAll(x => x.IsEnabled);
+            }
+
+            public static void ComputeLookupTables(double sensorElevation, double waterLevel)
+            {
+                foreach (Analysis.MeshVisualisation option in GetEnabledOptions())
+                    option.ComputeLookupTableForAnalysis((int)sensorElevation, (int)waterLevel);
+            }
+
+            public static Color? GetPixelColor(int depthPoint) // Get color for pixel given enabled options
+            {
+                foreach (Analysis.MeshVisualisation option in GetEnabledOptions())
+                {
+                    Color? analysisColor = option.GetPixelColorForAnalysis(depthPoint);
+                    if (analysisColor.HasValue)
+                        return analysisColor.Value;
+                }
+                return null;
+            }
+        }
+
+        public class VisualisationRangeWithColor 
+        {
+            /// <summary>Describes a numeric range (e.g. elevation/slope values) and color range to visualise it.</summary>
+            public int ValueStart { get; set; }
+            public int ValueEnd { get; set; }
+            public ColorHSL ColorStart { get; set; }
+            public ColorHSL ColorEnd { get; set; }
+
+            public ColorHSL InterpolateColor(double progress) // Progress is assumed to be a % value of 0.0 - 1.0
+            {
+                return new ColorHSL( 
+                    ColorStart.H + ((ColorEnd.H - ColorStart.H) * progress),
+                    ColorStart.S + ((ColorEnd.S - ColorStart.S) * progress),
+                    ColorStart.L + ((ColorEnd.L - ColorStart.L) * progress)
+                );
+            }
+        }
+
+        public abstract class MeshVisualisation 
+        {
+            /// <summary>Inherited by all possible analysis options (even if not coloring the mesh).</summary>
+            public string Name { get; } // Name used in the toggle menu
+            public bool IsExclusive { get; } // Whether this can be applied indepedently of other analysis
+            public bool IsEnabled { get; set; } // Whether to apply the analysis
+            public ToolStripMenuItem MenuItem { get; set; } 
+            public Dictionary<int, Color> lookupTable; // Dictionary of integers that map to color values
 
             public MeshVisualisation(string menuName, bool exclusive)
             {
-                name = menuName; 
-                isExclusive = exclusive;
-                isEnabled = false;
+                Name = menuName; 
+                IsExclusive = exclusive;
+                IsEnabled = false;
             }
 
-            public void ComputeLookupTable(double sensorElevation)
+            public void ComputeLinearRanges(params VisualisationRangeWithColor[] lookUpRanges)
             {
-                ComputeLookupTableForAnalysis(sensorElevation); 
-            }
-
-            public void ComputeLinearRange(int startIndex, int endIndex)
-            {
-                lookupTable = new Color[endIndex];
-                for (int i = startIndex; i > endIndex; i--)
+                int lookupTableMaximumSize = 0;
+                foreach (VisualisationRangeWithColor range in lookUpRanges)
                 {
-                    lookupTable[i] = new ColorHSL(0.01 + (i * 0.01), 1.0, 0.5).ToArgbColor();
+                    lookupTableMaximumSize += range.ValueEnd - range.ValueStart;
+                }
+
+                if (lookupTableMaximumSize == 0)
+                    return; // Can occur e.g. if the waterLevel is greater than the sensor height
+                else
+                    lookupTable = new Dictionary<int, Color>(lookupTableMaximumSize); // Init dict with needed size
+
+                // Populate dict values by interpolating colors within each of the lookup ranges
+                foreach (VisualisationRangeWithColor range in lookUpRanges) 
+                {
+                    for (int i = range.ValueStart; i < range.ValueEnd; i++)
+                    {
+                        double progress = ((double)i - range.ValueStart) / (range.ValueEnd - range.ValueStart);
+                        lookupTable[i] = range.InterpolateColor(progress);
+                    }
                 }
             }
-
-            public void ComputeBlockRange(int startIndex, int endIndex, Color color)
-            {
-                lookupTable = new Color[endIndex];
-                for (int i = startIndex; i > endIndex; i--)
-                {
-                    lookupTable[i] = color;
-                }
-            }
-
-            public abstract Color GetPixelColor(int elevation); // TODO: accept other inputs
-            public abstract void ComputeLookupTableForAnalysis(double sensorElevation);
+            
+            public abstract Color? GetPixelColorForAnalysis(int elevation);
+            public abstract void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel);
         }
 
         public class None : MeshVisualisation
         {
-            public None() : base("No Analysis", false) { }
+            public None() : base("No Visualisation", true) { }
 
-            public override Color GetPixelColor(int elevation) {
-                return Color.Transparent; // Never called as its lookup table has no items
+            public override Color? GetPixelColorForAnalysis(int elevation) {
+                return null; 
             }
 
-            public override void ComputeLookupTableForAnalysis(double sensorElevation) { }
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel) { }
         }
 
         public class Water : MeshVisualisation
         {
-            public Water() : base("Water Level", false) { }
+            public Water() : base("Show Water Level", false) { }
 
-            public override Color GetPixelColor(int elevation)
+            public override Color? GetPixelColorForAnalysis(int elevation)
             {
-                return lookupTable[elevation];
+                if (lookupTable.ContainsKey(elevation))
+                    return lookupTable[elevation]; // If the elevation is within the water level
+                else
+                    return null;
             }
 
-            public override void ComputeLookupTableForAnalysis(double waterLevel)
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel)
             {
-                ComputeBlockRange(0, (int)waterLevel, Color.Blue); 
-            }
-        }
-
-        public class Contours : MeshVisualisation
-        {
-            public Contours() : base("Contour Lines", false) { }
-
-            public override Color GetPixelColor(int elevation)
-            {
-                return Color.White; // TODO
-            }
-
-            public override void ComputeLookupTableForAnalysis(double sensorElevation)
-            {
-                // TODO - how to define a range of inputs? set the others to null?
+                VisualisationRangeWithColor waterRange = new VisualisationRangeWithColor
+                {
+                    // From the sensor's perspective water is between specified level and max height (i.e. upside down)
+                    ValueStart = sensorElevation - waterLevel, 
+                    ValueEnd = sensorElevation,
+                    ColorStart = new ColorHSL(0.55, 0.85, 0.25), 
+                    ColorEnd = new ColorHSL(0.61, 0.65, 0.65)
+                };
+                ComputeLinearRanges(new VisualisationRangeWithColor[] { waterRange }); 
             }
         }
-
 
         public class Elevation : MeshVisualisation
         {
-            public Elevation() : base("Elevation Analysis", false) { }
+            public Elevation() : base("Visualise Elevation", true) { }
 
-            public override Color GetPixelColor(int elevation)
+            public override Color? GetPixelColorForAnalysis(int elevation)
             {
-                return lookupTable[elevation];
+                if (lookupTable.ContainsKey(elevation))
+                    return lookupTable[elevation];
+                else
+                    return null;
             }
 
-            public override void ComputeLookupTableForAnalysis(double sensorElevation)
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel)
             {
-                ComputeLinearRange(0, (int)sensorElevation); 
+                VisualisationRangeWithColor elevationRange = new VisualisationRangeWithColor
+                {
+                    ValueStart = sensorElevation - 750, // TODO: don't assume maximum value here
+                    ValueEnd = sensorElevation,
+                    ColorStart = new ColorHSL(0.39, 0.39, 0.09),
+                    ColorEnd = new ColorHSL(0.43, 0.68, 0.45)
+                };
+                ComputeLinearRanges(new VisualisationRangeWithColor[] { elevationRange });
+
             }
         }
-
+        
         class Slope : MeshVisualisation
         {
-            public Slope() : base("Slope Analysis", false) { }
+            public Slope() : base("Visualise Slope", true) { }
 
-            public override Color GetPixelColor(int elevation)
+            public override Color? GetPixelColorForAnalysis(int slopeValue)
             {
-                return Color.White; // TODO
+                return null; // TODO
             }
 
-            public override void ComputeLookupTableForAnalysis(double sensorElevation)
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel)
             {
-                ComputeLinearRange(0, 90);
+                VisualisationRangeWithColor slopeRange = new VisualisationRangeWithColor
+                {
+                    ValueStart = 0, 
+                    ValueEnd = 90,
+                    ColorStart = new ColorHSL(1.0, 1.0, 1.0), // White
+                    ColorEnd = new ColorHSL(1.0, 1.0, 0.3) // Dark Red
+                };
+                ComputeLinearRanges(new VisualisationRangeWithColor[] { slopeRange });
             }
         }
 
         class Aspect : MeshVisualisation
         {
-            public Aspect() : base("Aspect Analysis", false) { }
+            public Aspect() : base("Visualise Aspect", true) { }
 
-            public override Color GetPixelColor(int elevation)
+            public override Color? GetPixelColorForAnalysis(int aspectValue)
             {
-                return Color.White; // TODO
+                return null; // TODO
             }
 
-            public override void ComputeLookupTableForAnalysis(double sensorElevation)
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel)
             {
-                ComputeLinearRange(0, 359);
+                VisualisationRangeWithColor rightAspect = new VisualisationRangeWithColor
+                {
+                    ValueStart = 0, 
+                    ValueEnd = 180,
+                    ColorStart = new ColorHSL(1.0, 1.0, 1.0), // White
+                    ColorEnd = new ColorHSL(1.0, 1.0, 0.3) // Dark Red
+                };
+                VisualisationRangeWithColor leftAspect = new VisualisationRangeWithColor
+                {
+                    ValueStart = 180, // For the other side of the aspect we loop back to the 0 value
+                    ValueEnd = 359,
+                    ColorStart = new ColorHSL(1.0, 1.0, 0.3), // Dark Red
+                    ColorEnd = new ColorHSL(1.0, 1.0, 1.0) // White
+                };
+                ComputeLinearRanges(new VisualisationRangeWithColor[] { rightAspect, leftAspect });
             }
-        }        
+        }
+
+
+        public class Contours : MeshVisualisation
+        {
+            public Contours() : base("Show Contour Lines", false) { }
+
+            public override Color? GetPixelColorForAnalysis(int elevation)
+            {
+                return null; 
+            }
+
+            public override void ComputeLookupTableForAnalysis(int sensorElevation, int waterLevel) { }
+        }
+
     }
 }

--- a/SandWorm/Core.cs
+++ b/SandWorm/Core.cs
@@ -46,25 +46,6 @@ namespace SandWorm
             return mesh;
         }
 
-        public static Color[] ComputeLookupTable(int waterLevel, Color[] lookupTable)
-        {
-            //precompute all vertex colors
-            int j = 0;
-            for (int i = waterLevel; i < lookupTable.Length; i++) //below water level
-            {
-                lookupTable[i] = new ColorHSL(0.6, 0.6, 0.60 - (j * 0.02)).ToArgbColor();
-                j++;
-            }
-
-            j = 0;
-            for (int i = waterLevel; i > 0; i--) //above water level
-            {
-                lookupTable[i] = new ColorHSL(0.01 + (j * 0.01), 1.0, 0.5).ToArgbColor();
-                j++;
-            }
-            return lookupTable;
-        }
-
         public struct PixelSize // Unfortunately no nice tuples in this version of C# :(
         {
             public double x;

--- a/SandWorm/SandWorm.csproj
+++ b/SandWorm/SandWorm.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Analysis.cs" />
     <Compile Include="Core.cs" />
     <Compile Include="GaussianBlur.cs" />
     <Compile Include="KinectController.cs" />


### PR DESCRIPTION
This is very much a work in progress / for feedback PR. This sketches out a series of classes in `Analysis.cs` that are each tied to a particular analysis/visualization method, such as the existing elevation/blank options, future options such as #13, and color/gradient variations. 

Each class should ideally:

- Compute a color lookup table (this may not be strictly necessary for all analysis methods, but could be a useful way to handle gradient customisation cleanly). 
- Compute the relevant color for a given pixel. This is easy for the current elevation method, but would involve distinct logic for slope/aspect
- Be able to store the variables used to present the analysis as an option in the context menu 
    - Some analysis options form mutually exclusive sets (i.e. slope vs aspect vs elevation) while others could be toggled independently (contours vs water vs ??)

I'm not super experienced with proper composition/inheritance patterns in C# so thought I would put this out there to see if its roughly appropriate. Feel free to revise/finish/trash as necessary. 