### PR TITLE
Add a separate setup component

### DIFF
--- a/SandWorm/Core.cs
+++ b/SandWorm/Core.cs
@@ -91,5 +91,42 @@ namespace SandWorm
             }
                 
         }
+
+        public static double ConvertDrawingUnits (Rhino.UnitSystem units)
+        {
+            double unitsMultiplier = 1.0;
+
+            switch (units.ToString())
+            {
+                case "Kilometers":
+                    unitsMultiplier = 0.0001;
+                    break;
+
+                case "Meters":
+                    unitsMultiplier = 0.001;
+                    break;
+
+                case "Decimeters":
+                    unitsMultiplier = 0.01;
+                    break;
+
+                case "Centimeters":
+                    unitsMultiplier = 0.1;
+                    break;
+
+                case "Millimeters":
+                    unitsMultiplier = 1.0;
+                    break;
+
+                case "Inches":
+                    unitsMultiplier = 0.0393701;
+                    break;
+
+                case "Feet":
+                    unitsMultiplier = 0.0328084;
+                    break;
+            }
+            return unitsMultiplier;
+        }
     }
 }

--- a/SandWorm/SandWorm.csproj
+++ b/SandWorm/SandWorm.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Core.cs" />
     <Compile Include="GaussianBlurProcessor.cs" />
     <Compile Include="KinectController.cs" />
+    <Compile Include="SandWormSetup.cs" />
     <Compile Include="SandWormComponent.cs" />
     <Compile Include="SandWormInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -8,13 +8,7 @@ using Microsoft.Kinect;
 using System.Windows.Forms;
 using System.Linq;
 
-// comment 
-// In order to load the result of this wizard, you will also need to
-// add the output bin/ folder of this project to the list of loaded
-// folder in Grasshopper.
-// You can use the _GrasshopperDeveloperSettings Rhino command for that.
 
-//Test comment
 namespace SandWorm
 {
     public class SandWorm : GH_Component
@@ -31,7 +25,7 @@ namespace SandWorm
         public Color[] vertexColors;
         public Mesh quadMesh = new Mesh();
 
-        public List<double> options;
+        public List<double> options; // List of options coming from the SWSetup component
 
         public double sensorElevation = 1000; // Arbitrary default value (must be >0)
         public int leftColumns = 0;
@@ -66,13 +60,7 @@ namespace SandWorm
         /// </summary>
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            //pManager.AddNumberParameter("SensorHeight", "SH", "The height (in document units) of the sensor above your model", GH_ParamAccess.item, sensorElevation);
             pManager.AddIntegerParameter("WaterLevel", "WL", "WaterLevel", GH_ParamAccess.item, 1000);
-            //pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
-            //pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
-            //pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
-            //pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
-            //pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
             pManager.AddIntegerParameter("AverageFrames", "AF", "Amount of depth frames to average across. This number has to be greater than zero.", GH_ParamAccess.item, averageFrames);
             pManager.AddIntegerParameter("BlurRadius", "BR", "Radius for Gaussian blur.", GH_ParamAccess.item, blurRadius);
             pManager.AddNumberParameter("SandWormOptions", "SWO", "Setup & Calibration options", GH_ParamAccess.list);
@@ -80,14 +68,6 @@ namespace SandWorm
             pManager[1].Optional = true;
             pManager[2].Optional = true;
             pManager[3].Optional = true;
-            /*
-            pManager[3].Optional = true;
-            pManager[4].Optional = true;
-            pManager[5].Optional = true;
-            pManager[6].Optional = true;
-            pManager[7].Optional = true;
-            pManager[8].Optional = true;
-            */
         }
 
         /// <summary>
@@ -111,7 +91,7 @@ namespace SandWorm
                     Menu_AppendSeparator(menu);
             }
         }
-        
+
 
         private void SetMeshVisualisation(object sender, EventArgs e)
         {
@@ -120,7 +100,7 @@ namespace SandWorm
             quadMesh.VertexColors.Clear(); // Must flush mesh colors to properly updated display
             ExpireSolution(true);
         }
-        
+
         private void ScheduleDelegate(GH_Document doc)
         {
             ExpireSolution(false);
@@ -133,20 +113,13 @@ namespace SandWorm
         /// to store data in output parameters.</param>
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            //DA.GetData<double>(0, ref sensorElevation);
+            options = new List<double>();
             DA.GetData<int>(0, ref waterLevel);
             DA.GetData<int>(1, ref averageFrames);
             DA.GetData<int>(2, ref blurRadius);
-            //DA.GetData<int>(2, ref leftColumns);
-            //DA.GetData<int>(3, ref rightColumns);
-            //DA.GetData<int>(4, ref topRows);
-            //DA.GetData<int>(5, ref bottomRows);
-            //DA.GetData<int>(6, ref tickRate);
-
-            options = new List<double>();
             DA.GetDataList<double>(3, options);
 
-            if (options.Count != 0)
+            if (options.Count != 0) // TODO add more robust checking whether all the options have been provided by the user
             {
                 sensorElevation = options[0];
                 leftColumns = (int)options[1];
@@ -156,39 +129,8 @@ namespace SandWorm
                 tickRate = (int)options[5];
             }
 
-
-            switch (units.ToString())
-            {
-                case "Kilometers":
-                    unitsMultiplier = 0.0001;
-                    break;
-
-                case "Meters":
-                    unitsMultiplier = 0.001;
-                    break;
-
-                case "Decimeters":
-                    unitsMultiplier = 0.01;
-                    break;
-
-                case "Centimeters":
-                    unitsMultiplier = 0.1;
-                    break;
-
-                case "Millimeters":
-                    unitsMultiplier = 1;
-                    break;
-
-                case "Inches":
-                    unitsMultiplier = 0.0393701;
-                    break;
-
-                case "Feet":
-                    unitsMultiplier = 0.0328084;
-                    break;
-            }
+            unitsMultiplier = Core.ConvertDrawingUnits(units); // Pick the correct multiplier based on the drawing units
             sensorElevation /= unitsMultiplier; // Standardise to mm to match sensor units
-            
 
             Stopwatch timer = Stopwatch.StartNew(); //debugging
 
@@ -204,7 +146,7 @@ namespace SandWorm
                 {
                     int trimmedWidth = KinectController.depthWidth - leftColumns - rightColumns;
                     int trimmedHeight = KinectController.depthHeight - topRows - bottomRows;
-                    
+
                     // initialize all arrays
                     pointCloud = new Point3d[trimmedWidth * trimmedHeight];
                     int[] depthFrameDataInt = new int[trimmedWidth * trimmedHeight];
@@ -213,8 +155,7 @@ namespace SandWorm
                     // initialize outputs
                     outputMesh = new List<Mesh>();
                     output = new List<string>(); //debugging
-                    output.Add(options.Count.ToString());
-                    
+
 
                     Point3d tempPoint = new Point3d();
                     Core.PixelSize depthPixelSize = Core.GetDepthPixelSpacing(sensorElevation);
@@ -223,7 +164,7 @@ namespace SandWorm
                     Core.CopyAsIntArray(KinectController.depthFrameData, depthFrameDataInt, leftColumns, rightColumns, topRows, bottomRows, KinectController.depthHeight, KinectController.depthWidth);
 
                     averageFrames = averageFrames < 1 ? 1 : averageFrames; //make sure there is at least one frame in the render buffer
-                    
+
                     // reset everything when resizing Kinect's field of view or changing the amounts of frame to average across
                     if (renderBuffer.Count > averageFrames || quadMesh.Faces.Count != (trimmedWidth - 2) * (trimmedHeight - 2))
                     {
@@ -254,10 +195,10 @@ namespace SandWorm
                                 renderBuffer.Last.Value[pixel] = (int)sensorElevation;
                             }
                         }
-                            
+
                         averagedDepthFrameData[pixel] = runningSum[pixel] / renderBuffer.Count; //calculate average values
 
-                        if (renderBuffer.Count >= averageFrames) 
+                        if (renderBuffer.Count >= averageFrames)
                             runningSum[pixel] -= renderBuffer.First.Value[pixel]; //subtract the oldest value from the sum 
                     }
 
@@ -274,7 +215,7 @@ namespace SandWorm
                         timer.Restart(); //debugging
                     }
 
-                    
+
                     // Setup variables for the coloring process
                     Analysis.AnalysisManager.ComputeLookupTables(sensorElevation); // First-run computing of tables
                     var enabledMeshColoring = Analysis.AnalysisManager.GetEnabledMeshColoring();
@@ -282,7 +223,7 @@ namespace SandWorm
                     var hasColorTable = enabledColorTable.Length > 0; // Setting the 'no analysis' option == empty table  
                     vertexColors = new Color[hasColorTable ? trimmedWidth * trimmedHeight : 0]; // A 0-length array wont be used in meshing
                     var pixelsForAnalysis = new Point3d[4];
-                    
+
 
                     // Setup variables for per-pixel loop
                     pointCloud = new Point3d[trimmedWidth * trimmedHeight];
@@ -297,17 +238,17 @@ namespace SandWorm
                             tempPoint.Z = (depthPoint - sensorElevation) * -unitsMultiplier;
 
                             pointCloud[arrayIndex] = tempPoint; // Add new point to point cloud itself
-                            
+
                             if (hasColorTable) // Perform analysis as needed and lookup result in table
                             {
                                 var pixelIndex = enabledMeshColoring.GetPixelIndexForAnalysis(tempPoint, pixelsForAnalysis);
                                 vertexColors[arrayIndex] = enabledColorTable[pixelIndex];
                             }
-                            
+
                             arrayIndex++;
                         }
                     }
-                   
+
                     //keep only the desired amount of frames in the buffer
                     while (renderBuffer.Count >= averageFrames)
                     {

--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -31,12 +31,14 @@ namespace SandWorm
         public Color[] vertexColors;
         public Mesh quadMesh = new Mesh();
 
+        public List<double> options;
+
         public double sensorElevation = 1000; // Arbitrary default value (must be >0)
         public int leftColumns = 0;
         public int rightColumns = 0;
         public int topRows = 0;
         public int bottomRows = 0;
-        public int tickRate = 20; // In ms
+        public int tickRate = 33; // In ms
         public int averageFrames = 1;
         public int blurRadius = 1;
         public static Rhino.UnitSystem units = Rhino.RhinoDoc.ActiveDoc.ModelUnitSystem;
@@ -64,24 +66,28 @@ namespace SandWorm
         /// </summary>
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddNumberParameter("SensorHeight", "SH", "The height (in document units) of the sensor above your model", GH_ParamAccess.item, sensorElevation);
+            //pManager.AddNumberParameter("SensorHeight", "SH", "The height (in document units) of the sensor above your model", GH_ParamAccess.item, sensorElevation);
             pManager.AddIntegerParameter("WaterLevel", "WL", "WaterLevel", GH_ParamAccess.item, 1000);
-            pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
-            pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
-            pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
-            pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
-            pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
+            //pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
+            //pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
+            //pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
+            //pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
+            //pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
             pManager.AddIntegerParameter("AverageFrames", "AF", "Amount of depth frames to average across. This number has to be greater than zero.", GH_ParamAccess.item, averageFrames);
             pManager.AddIntegerParameter("BlurRadius", "BR", "Radius for Gaussian blur.", GH_ParamAccess.item, blurRadius);
+            pManager.AddNumberParameter("SandWormOptions", "SWO", "Setup & Calibration options", GH_ParamAccess.list);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
             pManager[2].Optional = true;
+            pManager[3].Optional = true;
+            /*
             pManager[3].Optional = true;
             pManager[4].Optional = true;
             pManager[5].Optional = true;
             pManager[6].Optional = true;
             pManager[7].Optional = true;
             pManager[8].Optional = true;
+            */
         }
 
         /// <summary>
@@ -105,6 +111,7 @@ namespace SandWorm
                     Menu_AppendSeparator(menu);
             }
         }
+        
 
         private void SetMeshVisualisation(object sender, EventArgs e)
         {
@@ -113,7 +120,7 @@ namespace SandWorm
             quadMesh.VertexColors.Clear(); // Must flush mesh colors to properly updated display
             ExpireSolution(true);
         }
-
+        
         private void ScheduleDelegate(GH_Document doc)
         {
             ExpireSolution(false);
@@ -126,15 +133,29 @@ namespace SandWorm
         /// to store data in output parameters.</param>
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            DA.GetData<double>(0, ref sensorElevation);
-            DA.GetData<int>(1, ref waterLevel);
-            DA.GetData<int>(2, ref leftColumns);
-            DA.GetData<int>(3, ref rightColumns);
-            DA.GetData<int>(4, ref topRows);
-            DA.GetData<int>(5, ref bottomRows);
-            DA.GetData<int>(6, ref tickRate);
-            DA.GetData<int>(7, ref averageFrames);
-            DA.GetData<int>(8, ref blurRadius);
+            //DA.GetData<double>(0, ref sensorElevation);
+            DA.GetData<int>(0, ref waterLevel);
+            DA.GetData<int>(1, ref averageFrames);
+            DA.GetData<int>(2, ref blurRadius);
+            //DA.GetData<int>(2, ref leftColumns);
+            //DA.GetData<int>(3, ref rightColumns);
+            //DA.GetData<int>(4, ref topRows);
+            //DA.GetData<int>(5, ref bottomRows);
+            //DA.GetData<int>(6, ref tickRate);
+
+            options = new List<double>();
+            DA.GetDataList<double>(3, options);
+
+            if (options.Count != 0)
+            {
+                sensorElevation = options[0];
+                leftColumns = (int)options[1];
+                rightColumns = (int)options[2];
+                topRows = (int)options[3];
+                bottomRows = (int)options[4];
+                tickRate = (int)options[5];
+            }
+
 
             switch (units.ToString())
             {
@@ -166,7 +187,8 @@ namespace SandWorm
                     unitsMultiplier = 0.0328084;
                     break;
             }
-            sensorElevation /= unitsMultiplier; // Standardise to mm to match sensor units 
+            sensorElevation /= unitsMultiplier; // Standardise to mm to match sensor units
+            
 
             Stopwatch timer = Stopwatch.StartNew(); //debugging
 
@@ -191,6 +213,8 @@ namespace SandWorm
                     // initialize outputs
                     outputMesh = new List<Mesh>();
                     output = new List<string>(); //debugging
+                    output.Add(options.Count.ToString());
+                    
 
                     Point3d tempPoint = new Point3d();
                     Core.PixelSize depthPixelSize = Core.GetDepthPixelSpacing(sensorElevation);
@@ -250,6 +274,7 @@ namespace SandWorm
                         timer.Restart(); //debugging
                     }
 
+                    
                     // Setup variables for the coloring process
                     Analysis.AnalysisManager.ComputeLookupTables(sensorElevation); // First-run computing of tables
                     var enabledMeshColoring = Analysis.AnalysisManager.GetEnabledMeshColoring();
@@ -257,6 +282,7 @@ namespace SandWorm
                     var hasColorTable = enabledColorTable.Length > 0; // Setting the 'no analysis' option == empty table  
                     vertexColors = new Color[hasColorTable ? trimmedWidth * trimmedHeight : 0]; // A 0-length array wont be used in meshing
                     var pixelsForAnalysis = new Point3d[4];
+                    
 
                     // Setup variables for per-pixel loop
                     pointCloud = new Point3d[trimmedWidth * trimmedHeight];
@@ -271,11 +297,13 @@ namespace SandWorm
                             tempPoint.Z = (depthPoint - sensorElevation) * -unitsMultiplier;
 
                             pointCloud[arrayIndex] = tempPoint; // Add new point to point cloud itself
+                            
                             if (hasColorTable) // Perform analysis as needed and lookup result in table
                             {
                                 var pixelIndex = enabledMeshColoring.GetPixelIndexForAnalysis(tempPoint, pixelsForAnalysis);
                                 vertexColors[arrayIndex] = enabledColorTable[pixelIndex];
                             }
+                            
                             arrayIndex++;
                         }
                     }

--- a/SandWorm/SandWormSetup.cs
+++ b/SandWorm/SandWormSetup.cs
@@ -8,6 +8,16 @@ namespace SandWorm
 {
     public class SandWormSetup : GH_Component
     {
+
+        public double sensorElevation = 1000; // Arbitrary default value (must be >0)
+        public int leftColumns = 0;
+        public int rightColumns = 0;
+        public int topRows = 0;
+        public int bottomRows = 0;
+        public int tickRate = 33; // In ms
+
+        public double[] options = new double[6];
+
         /// <summary>
         /// Initializes a new instance of the MyComponent1 class.
         /// </summary>
@@ -23,9 +33,18 @@ namespace SandWorm
         /// </summary>
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
+            pManager.AddNumberParameter("SensorHeight", "SH", "The height (in document units) of the sensor above your model", GH_ParamAccess.item, sensorElevation);
             pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
+            pManager[0].Optional = true;
+            pManager[1].Optional = true;
+            pManager[2].Optional = true;
+            pManager[3].Optional = true;
+            pManager[4].Optional = true;
+            pManager[5].Optional = true;
         }
 
         /// <summary>
@@ -33,7 +52,7 @@ namespace SandWorm
         /// </summary>
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddTextParameter("Output", "O", "Output", GH_ParamAccess.list); //debugging
+            pManager.AddGenericParameter ("Options", "O", "SandWorm oOptions", GH_ParamAccess.list); //debugging
         }
 
         /// <summary>
@@ -42,7 +61,22 @@ namespace SandWorm
         /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
         protected override void SolveInstance(IGH_DataAccess DA)
         {
+            DA.GetData<double>(0, ref sensorElevation);
+            DA.GetData<int>(1, ref leftColumns);
+            DA.GetData<int>(2, ref rightColumns);
+            DA.GetData<int>(3, ref topRows);
+            DA.GetData<int>(4, ref bottomRows);
+            DA.GetData<int>(5, ref tickRate);
 
+
+            options[0] = sensorElevation;
+            options[1] = leftColumns;
+            options[2] = rightColumns;
+            options[3] = topRows;
+            options[4] = bottomRows;
+            options[5] = tickRate;
+            
+            DA.SetDataList(0, options);
         }
 
         /// <summary>

--- a/SandWorm/SandWormSetup.cs
+++ b/SandWorm/SandWormSetup.cs
@@ -68,7 +68,6 @@ namespace SandWorm
             DA.GetData<int>(4, ref bottomRows);
             DA.GetData<int>(5, ref tickRate);
 
-
             options[0] = sensorElevation;
             options[1] = leftColumns;
             options[2] = rightColumns;

--- a/SandWorm/SandWormSetup.cs
+++ b/SandWorm/SandWormSetup.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Grasshopper.Kernel;
+using Rhino.Geometry;
+
+namespace SandWorm
+{
+    public class SandWormSetup : GH_Component
+    {
+        /// <summary>
+        /// Initializes a new instance of the MyComponent1 class.
+        /// </summary>
+        public SandWormSetup()
+          : base("SandWormSetup", "SWSetup",
+              "This component takes care of all the setup & calibration of your sandbox.",
+              "Sandworm", "Sandbox")
+        {
+        }
+
+        /// <summary>
+        /// Registers all the input parameters for this component.
+        /// </summary>
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+        {
+            pManager.AddIntegerParameter("LeftColumns", "LC", "Number of columns to trim from the left", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("RightColumns", "RC", "Number of columns to trim from the right", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
+        }
+
+        /// <summary>
+        /// Registers all the output parameters for this component.
+        /// </summary>
+        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
+        {
+            pManager.AddTextParameter("Output", "O", "Output", GH_ParamAccess.list); //debugging
+        }
+
+        /// <summary>
+        /// This is the method that actually does the work.
+        /// </summary>
+        /// <param name="DA">The DA object is used to retrieve from inputs and store in outputs.</param>
+        protected override void SolveInstance(IGH_DataAccess DA)
+        {
+
+        }
+
+        /// <summary>
+        /// Provides an Icon for the component.
+        /// </summary>
+        protected override System.Drawing.Bitmap Icon
+        {
+            get
+            {
+                //You can add image files to your project resources and access them like this:
+                // return Resources.IconForThisComponent;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the unique ID for this component. Do not change this ID after release.
+        /// </summary>
+        public override Guid ComponentGuid
+        {
+            get { return new Guid("9ee53381-c269-4fff-9d45-8a2dbefc243c"); }
+        }
+    }
+}


### PR DESCRIPTION
First take on adding an external setup component. For now, there is no additional logic, just offloading some input for the sake of a cleaner UI. This partially addresses #1 and #20.

The reasoning behind this is that once users have setup their Sandbox, they wouldn't have to fiddle with these sliders and all of the inputs can be defined through the standard right-click -> Set Multiple Numbers option.
![image](https://user-images.githubusercontent.com/49192999/65384612-89aeb480-dd24-11e9-9897-61ee56faa553.png)

Didn't want to merge just yet, to prevent breaking stuff that you are currently working on. Feel free to do it, though, if you think it doesn't have any ramifications on the Analysis Manager.