### PR TITLE
Implement multiframe capture; closes #46

### DIFF
--- a/SandWorm/SandWormSetup.cs
+++ b/SandWorm/SandWormSetup.cs
@@ -15,8 +15,9 @@ namespace SandWorm
         public int topRows = 0;
         public int bottomRows = 0;
         public int tickRate = 33; // In ms
+        public int keepFrames = 1; // In ms
 
-        public double[] options = new double[6];
+        public double[] options = new double[7];
 
         /// <summary>
         /// Initializes a new instance of the MyComponent1 class.
@@ -39,12 +40,14 @@ namespace SandWorm
             pManager.AddIntegerParameter("TopRows", "TR", "Number of rows to trim from the top", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("BottomRows", "BR", "Number of rows to trim from the bottom", GH_ParamAccess.item, 0);
             pManager.AddIntegerParameter("TickRate", "TR", "The time interval, in milliseconds, to update geometry from the Kinect. Set as 0 to disable automatic updates.", GH_ParamAccess.item, tickRate);
+            pManager.AddIntegerParameter("KeepFrames", "KF", "Output a running list of a frame updates rather than just the current frame. Set to 1 or 0 to disable.", GH_ParamAccess.item, keepFrames);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
             pManager[2].Optional = true;
             pManager[3].Optional = true;
             pManager[4].Optional = true;
             pManager[5].Optional = true;
+            pManager[6].Optional = true;
         }
 
         /// <summary>
@@ -67,6 +70,7 @@ namespace SandWorm
             DA.GetData<int>(3, ref topRows);
             DA.GetData<int>(4, ref bottomRows);
             DA.GetData<int>(5, ref tickRate);
+            DA.GetData<int>(6, ref keepFrames);
 
             options[0] = sensorElevation;
             options[1] = leftColumns;
@@ -74,7 +78,8 @@ namespace SandWorm
             options[3] = topRows;
             options[4] = bottomRows;
             options[5] = tickRate;
-            
+            options[6] = keepFrames;
+
             DA.SetDataList(0, options);
         }
 


### PR DESCRIPTION
Implementation as discussed/described in #46. It seems pretty robust, however a high number of keepFrames is not particularly performant, I assume just due to Rhino displaying so many meshes at once. 

The implementation doesn't handle spacing at all, so generally users will want to use a `series` to space out the objects. This also only makes sense with a manual, or very high tick rate, and with frame averaging set to a low number. When used this way it is an easy way to take a series of 'snapshots' of the models and (if you setup the timing well or use data dams) to capture dynamic behavior such as the effect of water/wind used for analogue simulation. 