### PR TITLE
Feature/#47 aspect

### DIFF
--- a/SandWorm/Analytics/Aspect.cs
+++ b/SandWorm/Analytics/Aspect.cs
@@ -33,31 +33,111 @@ namespace SandWorm.Analytics
             // These x/y tilts are treated as a vector that is thus the average orientation in X/Y 
             // This vector's angle is then measured relative to the up direction 
             // The tilts within diagonal axes are halved and added equally to each X/Y component
-                       
-            // first row
+            double deltaLR, deltaTB, deltaTLBR, deltaTRBL, deltaX, deltaY, radianAngle, normalisedDegreeAngle;
+
+            // First pixel NW
+            deltaLR = pixelArray[1]; // E 
+            deltaTB = pixelArray[width]; // S
+            deltaTLBR = pixelArray[width + 1]; // SE;
+
+            deltaX = deltaLR - (deltaTLBR * 0.5);
+            deltaY = deltaTB - (deltaTLBR * 0.5);
+            radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+            normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+            vertexColors[0] = GetColorForAspect((short)normalisedDegreeAngle);
+
+            // Last pixel NE
+            deltaLR = pixelArray[width - 2]; // W
+            deltaTB = pixelArray[2 * width - 1]; // S
+            deltaTRBL = pixelArray[2 * width - 1]; // SW
+
+            deltaX = deltaLR - (deltaTRBL * 0.5);
+            deltaY = deltaTB - (deltaTRBL * 0.5);
+            radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+            normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+            vertexColors[width - 1] = GetColorForAspect((short)normalisedDegreeAngle);
+
+            // First pixel SW
+            deltaLR = pixelArray[(height - 1) * width + 1]; // E 
+            deltaTB = pixelArray[(height - 2) * width]; // N 
+            deltaTRBL = pixelArray[(height - 2) * width + 1]; // NE 
+
+            deltaX = deltaLR - (deltaTRBL * 0.5);
+            deltaY = deltaTB - (deltaTRBL * 0.5);
+            radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+            normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+            vertexColors[(height - 1) * width] = GetColorForAspect((short)normalisedDegreeAngle);
+
+            // Last pixel SE
+            deltaLR = pixelArray[height * width - 2]; // W
+            deltaTB = pixelArray[(height - 1) * width - 1]; // N
+            deltaTLBR = pixelArray[(height - 1) * width - 2]; // NW 
+
+            deltaX = deltaLR - (deltaTLBR * 0.5);
+            deltaY = deltaTB - (deltaTLBR * 0.5);
+            radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+            normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+            vertexColors[height * width - 1] = GetColorForAspect((short)normalisedDegreeAngle);
+
+            // First row
             for (int x = 1; x < width - 1; x++)
             {
-                // vertexColors[i] = GetColorForAspect((short)angle);
+                deltaLR = pixelArray[x + 1] - pixelArray[x - 1]; // E - W
+                deltaTB = pixelArray[x + width]; // S
+                deltaTLBR = pixelArray[x + width - 1]; // SW 
+                deltaTRBL = pixelArray[x + width + 1]; // SE 
+
+                deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+                normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+                vertexColors[x] = GetColorForAspect((short)normalisedDegreeAngle);
             }
 
-            // last row
+            // Last row
             for (int x = (height - 1) * width + 1; x < height * width - 1; x++)
             {
-                // vertexColors[i] = GetColorForAspect((short)angle);
+                deltaLR = pixelArray[x + 1] - pixelArray[x - 1]; // E - W
+                deltaTB = pixelArray[x - width]; // N
+                deltaTLBR = pixelArray[x - width - 1]; // NW 
+                deltaTRBL = pixelArray[x - width + 1]; // NE 
+
+                deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+                normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+                vertexColors[x] = GetColorForAspect((short)normalisedDegreeAngle);
             }
 
-            // first column
+            // First column
             for (int x = width; x < (height - 1) * width; x += width)
             {
-                // vertexColors[i] = GetColorForAspect((short)angle);
+                deltaLR = pixelArray[x + 1]; // E 
+                deltaTB = pixelArray[x - width] - pixelArray[x + width]; // N - S
+                deltaTLBR = pixelArray[x + width + 1]; // SE
+                deltaTRBL = pixelArray[x - width + 1]; // NE
+
+                deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+                normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+                vertexColors[x] = GetColorForAspect((short)normalisedDegreeAngle);
             }
 
-            // last column
+            // Last column
             for (int x = 2 * width - 1; x < height * width - 1; x += width)
             {
-                // vertexColors[i] = GetColorForAspect((short)angle);
-            }
+                deltaLR = pixelArray[x - 1]; // W
+                deltaTB = pixelArray[x - width] - pixelArray[x + width]; // N - S
+                deltaTLBR = pixelArray[x - width - 1]; // NW 
+                deltaTRBL = pixelArray[x + width - 1]; // SW
 
+                deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                radianAngle = (Math.Atan2(deltaX, deltaY) - Math.Atan2(0, 1));
+                normalisedDegreeAngle = (radianAngle * (180 / Math.PI)) + 180;
+                vertexColors[x] = GetColorForAspect((short)normalisedDegreeAngle);
+            }
 
             // Rest of the array
             Parallel.For(1, height - 1, rows => // Iterate over y dimension
@@ -68,15 +148,17 @@ namespace SandWorm.Analytics
                     var i = rows * width + columns;
                     var j = (rows + 1) * width + columns;
 
-                    var deltaLR = pixelArray[i + 1] - pixelArray[i - 1]; // E - W
-                    var deltaTB = pixelArray[h] - pixelArray[j]; // N - S
-                    var deltaTLBR = pixelArray[h - 1] - pixelArray[j + 1]; // NW - SE
-                    var deltaTRBL = pixelArray[h + 1] - pixelArray[j - 1]; // NE - SW
+                    // Note using inline variable prefix to localise references in parallel ops
+                    var inlineDeltaLR = pixelArray[i + 1] - pixelArray[i - 1]; // E - W
+                    var inlineDeltaTB = pixelArray[h] - pixelArray[j]; // N - S
+                    var inlineDeltaTLBR = pixelArray[h - 1] - pixelArray[j + 1]; // NW - SE
+                    var inlineDeltaTRBL = pixelArray[h + 1] - pixelArray[j - 1]; // NE - SW
 
-                    var deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
-                    var deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
-                    var angle = (Math.Atan2(deltaX, 1 - deltaY) * (180 / Math.PI) * -1) + 180;
-                    vertexColors[i] = GetColorForAspect((short) angle);
+                    var inlineDeltaX = inlineDeltaLR - (inlineDeltaTLBR * 0.5) - (inlineDeltaTRBL * 0.5);
+                    var inlineDeltaY = inlineDeltaTB - (inlineDeltaTLBR * 0.5) - (inlineDeltaTRBL * 0.5);
+                    var inlineRadians = (Math.Atan2(inlineDeltaLR, inlineDeltaTB) - Math.Atan2(0, 1));
+                    var inlineNormalisedDegrees = (inlineRadians * (180 / Math.PI)) + 180;
+                    vertexColors[i] = GetColorForAspect((short)inlineNormalisedDegrees);
                 }
             });
 
@@ -85,34 +167,30 @@ namespace SandWorm.Analytics
 
         public override void ComputeLookupTableForAnalysis(double sensorElevation)
         {
+            var north = new ColorHSL(0.7, 1, 0.90); // North = Blue
+            var east = new ColorHSL(0.9, 1, 0.5); // East = Pink
+            var south = new ColorHSL(0.5, 0, 0.10); // South = Black
+            var west = new ColorHSL(0.5, 1, 0.5); // West = Teal
+
             // The angle range coming from the calculation is -180 to +180; which then has 180 added to normalise as 0-360
             // So our color span starts at South (-180 > 0) and proceeds clockwise to North (0 > 180) and then South (180 > 360)
-
-            var SWAspect = new Analysis.VisualisationRangeWithColor
-            {
-                ValueSpan = 90, // For the other side of the aspect we loop back to the 0 value
-                ColorStart = new ColorHSL(1.0, 1.0, 0.0), // South = Black
-                ColorEnd = new ColorHSL(0.5, 1.0, 0.5) // West = Blue
-            };
             var NWAspect = new Analysis.VisualisationRangeWithColor
             {
-                ValueSpan = 90, // For the other side of the aspect we loop back to the 0 value
-                ColorStart = new ColorHSL(0.5, 1.0, 0.5), // West = Blue
-                ColorEnd = new ColorHSL(1.0, 1.0, 1.0) // North = White
+                ValueSpan = 90, ColorStart = south, ColorEnd = east 
             };
-            var NEAspect = new Analysis.VisualisationRangeWithColor
+            var SWAspect = new Analysis.VisualisationRangeWithColor
             {
-                ValueSpan = 90,
-                ColorStart = new ColorHSL(1.0, 1.0, 1.0), // North = White
-                ColorEnd = new ColorHSL(1.0, 1.0, 0.5) // East = Red
+                ValueSpan = 90, ColorStart = east, ColorEnd = north
             };
             var SEAspect = new Analysis.VisualisationRangeWithColor
             {
-                ValueSpan = 90,
-                ColorStart = new ColorHSL(1.0, 1.0, 0.5), // East = Red
-                ColorEnd = new ColorHSL(1.0, 1.0, 0.0) // South = Black
+                ValueSpan = 90, ColorStart = north, ColorEnd = west
             };
-            ComputeLinearRanges(SWAspect, NWAspect, NEAspect, SEAspect);
+            var NEAspect = new Analysis.VisualisationRangeWithColor
+            {
+                ValueSpan = 90, ColorStart = west, ColorEnd = south
+            };
+            ComputeLinearRanges(NWAspect, SWAspect, SEAspect, NEAspect);
         }
     }
 }

--- a/SandWorm/Analytics/Aspect.cs
+++ b/SandWorm/Analytics/Aspect.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
+using System.Threading.Tasks;
 using Rhino.Display;
-using Rhino.Geometry;
 
 namespace SandWorm.Analytics
 {
@@ -12,31 +11,108 @@ namespace SandWorm.Analytics
         {
         }
 
-        public void GetColorCloudForAnalysis(ref Color[] vertexColors, double[] pixelArray)
+        private Color GetColorForAspect(short aspectValue)
+        {
+            if (aspectValue >= lookupTable.Length)
+                return lookupTable[lookupTable.Length - 1];
+            if (aspectValue < 0)
+                return lookupTable[0];
+            return lookupTable[aspectValue];
+        }
+
+        public Color[] GetColorCloudForAnalysis(double[] pixelArray, int width, int height)
         {
             if (lookupTable == null)
             {
                 ComputeLookupTableForAnalysis(0.0);
             }
+            var vertexColors = new Color[pixelArray.Length];
 
-            vertexColors = new Color[pixelArray.Length];
+            // The approach below finds the difference in elevation along the X and Y axis
+            // i.e. a difference of -10 in the X indicates a tilt to the left/west
+            // These x/y tilts are treated as a vector that is thus the average orientation in X/Y 
+            // This vector's angle is then measured relative to the up direction 
+            // The tilts within diagonal axes are halved and added equally to each X/Y component
+                       
+            // first row
+            for (int x = 1; x < width - 1; x++)
+            {
+                // vertexColors[i] = GetColorForAspect((short)angle);
+            }
+
+            // last row
+            for (int x = (height - 1) * width + 1; x < height * width - 1; x++)
+            {
+                // vertexColors[i] = GetColorForAspect((short)angle);
+            }
+
+            // first column
+            for (int x = width; x < (height - 1) * width; x += width)
+            {
+                // vertexColors[i] = GetColorForAspect((short)angle);
+            }
+
+            // last column
+            for (int x = 2 * width - 1; x < height * width - 1; x += width)
+            {
+                // vertexColors[i] = GetColorForAspect((short)angle);
+            }
+
+
+            // Rest of the array
+            Parallel.For(1, height - 1, rows => // Iterate over y dimension
+            {
+                for (var columns = 1; columns < width - 1; columns++) // Iterate over x dimension
+                {
+                    var h = (rows - 1) * width + columns;
+                    var i = rows * width + columns;
+                    var j = (rows + 1) * width + columns;
+
+                    var deltaLR = pixelArray[i + 1] - pixelArray[i - 1]; // E - W
+                    var deltaTB = pixelArray[h] - pixelArray[j]; // N - S
+                    var deltaTLBR = pixelArray[h - 1] - pixelArray[j + 1]; // NW - SE
+                    var deltaTRBL = pixelArray[h + 1] - pixelArray[j - 1]; // NE - SW
+
+                    var deltaX = deltaLR - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                    var deltaY = deltaTB - (deltaTLBR * 0.5) - (deltaTRBL * 0.5);
+                    var angle = (Math.Atan2(deltaX, 1 - deltaY) * (180 / Math.PI) * -1) + 180;
+                    vertexColors[i] = GetColorForAspect((short) angle);
+                }
+            });
+
+            return vertexColors;
         }
 
         public override void ComputeLookupTableForAnalysis(double sensorElevation)
         {
-            var rightAspect = new Analysis.VisualisationRangeWithColor
+            // The angle range coming from the calculation is -180 to +180; which then has 180 added to normalise as 0-360
+            // So our color span starts at South (-180 > 0) and proceeds clockwise to North (0 > 180) and then South (180 > 360)
+
+            var SWAspect = new Analysis.VisualisationRangeWithColor
             {
-                ValueSpan = 180,
-                ColorStart = new ColorHSL(1.0, 1.0, 1.0), // White
-                ColorEnd = new ColorHSL(1.0, 1.0, 0.3) // Dark Red
+                ValueSpan = 90, // For the other side of the aspect we loop back to the 0 value
+                ColorStart = new ColorHSL(1.0, 1.0, 0.0), // South = Black
+                ColorEnd = new ColorHSL(0.5, 1.0, 0.5) // West = Blue
             };
-            var leftAspect = new Analysis.VisualisationRangeWithColor
+            var NWAspect = new Analysis.VisualisationRangeWithColor
             {
-                ValueSpan = 180, // For the other side of the aspect we loop back to the 0 value
-                ColorStart = new ColorHSL(1.0, 1.0, 0.3), // Dark Red
-                ColorEnd = new ColorHSL(1.0, 1.0, 1.0) // White
+                ValueSpan = 90, // For the other side of the aspect we loop back to the 0 value
+                ColorStart = new ColorHSL(0.5, 1.0, 0.5), // West = Blue
+                ColorEnd = new ColorHSL(1.0, 1.0, 1.0) // North = White
             };
-            ComputeLinearRanges(rightAspect, leftAspect);
+            var NEAspect = new Analysis.VisualisationRangeWithColor
+            {
+                ValueSpan = 90,
+                ColorStart = new ColorHSL(1.0, 1.0, 1.0), // North = White
+                ColorEnd = new ColorHSL(1.0, 1.0, 0.5) // East = Red
+            };
+            var SEAspect = new Analysis.VisualisationRangeWithColor
+            {
+                ValueSpan = 90,
+                ColorStart = new ColorHSL(1.0, 1.0, 0.5), // East = Red
+                ColorEnd = new ColorHSL(1.0, 1.0, 0.0) // South = Black
+            };
+            ComputeLinearRanges(SWAspect, NWAspect, NEAspect, SEAspect);
         }
     }
 }

--- a/SandWorm/Analytics/Slope.cs
+++ b/SandWorm/Analytics/Slope.cs
@@ -15,7 +15,7 @@ namespace SandWorm.Analytics
         {
         }
 
-        private Color getColorForSlope(ushort slopeValue)
+        private Color GetColorForSlope(ushort slopeValue)
         {
             if (slopeValue > maximumSlope)
                 return lookupTable[lookupTable.Length - 1];
@@ -40,7 +40,7 @@ namespace SandWorm.Analytics
             slope += Math.Abs(pixelArray[width] - pixelArray[0]) / deltaY; // S Pixel
             slope += Math.Abs(pixelArray[width + 1] - pixelArray[0]) / deltaXY; // SE Pixel
 
-            vertexColors[0] = getColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
+            vertexColors[0] = GetColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
 
             // last pixel NE
             slope = 0.0;
@@ -48,7 +48,7 @@ namespace SandWorm.Analytics
             slope += Math.Abs(pixelArray[2 * width - 1] - pixelArray[width - 1]) / deltaY; // S Pixel
             slope += Math.Abs(pixelArray[2 * width - 2] - pixelArray[width - 1]) / deltaXY; // SW Pixel
 
-            vertexColors[width - 1] = getColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
+            vertexColors[width - 1] = GetColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
 
             // first pixel SW
             slope = 0.0;
@@ -56,7 +56,7 @@ namespace SandWorm.Analytics
             slope += Math.Abs(pixelArray[(height - 2) * width] - pixelArray[(height - 1) * width]) / deltaY; // N Pixel
             slope += Math.Abs(pixelArray[(height - 2) * width + 1] - pixelArray[(height - 1) * width]) / deltaXY; //NE Pixel
 
-            vertexColors[(height - 1) * width] = getColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
+            vertexColors[(height - 1) * width] = GetColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
 
             // last pixel SE
             slope = 0.0;
@@ -64,7 +64,7 @@ namespace SandWorm.Analytics
             slope += Math.Abs(pixelArray[(height - 1) * width - 1] - pixelArray[height * width - 1]) / deltaY; // N Pixel
             slope += Math.Abs(pixelArray[(height - 1) * width - 2] - pixelArray[height * width - 1]) / deltaXY; //NW Pixel
 
-            vertexColors[height * width - 1] = getColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
+            vertexColors[height * width - 1] = GetColorForSlope((ushort)(slope * 33.33)); // Divide by 3 multiply by 100 => 33.33
 
             // first row
             for (int x = 1; x < width - 1; x++)
@@ -76,7 +76,7 @@ namespace SandWorm.Analytics
                 slope += Math.Abs(pixelArray[x + width] - pixelArray[x]) / deltaY; // S Pixel
                 slope += Math.Abs(pixelArray[x + width + 1] - pixelArray[x]) / deltaXY; // SE Pixel
 
-                vertexColors[x] = getColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
+                vertexColors[x] = GetColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
             }
 
             // last row
@@ -89,7 +89,7 @@ namespace SandWorm.Analytics
                 slope += Math.Abs(pixelArray[x - width] - pixelArray[x]) / deltaY; // N Pixel
                 slope += Math.Abs(pixelArray[x - width + 1] - pixelArray[x]) / deltaXY; // NE Pixel
 
-                vertexColors[x] = getColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
+                vertexColors[x] = GetColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
             }
 
             // first column
@@ -102,7 +102,7 @@ namespace SandWorm.Analytics
                 slope += Math.Abs(pixelArray[x + 1] - pixelArray[x]) / deltaX; // E Pixel
                 slope += Math.Abs(pixelArray[x + width + 1] - pixelArray[x]) / deltaXY; // SE Pixel
 
-                vertexColors[x] = getColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
+                vertexColors[x] = GetColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
             }
 
             // last column
@@ -115,7 +115,7 @@ namespace SandWorm.Analytics
                 slope += Math.Abs(pixelArray[x - 1] - pixelArray[x]) / deltaX; // W Pixel
                 slope += Math.Abs(pixelArray[x + width - 1] - pixelArray[x]) / deltaXY; // SW Pixel
 
-                vertexColors[x] = getColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
+                vertexColors[x] = GetColorForSlope((ushort)(slope * 20.0)); // Divide by 5 multiply by 100 => 20.0
             }
 
             // rest of the array
@@ -137,7 +137,7 @@ namespace SandWorm.Analytics
                     parallelSlope += Math.Abs((pixelArray[j] - pixelArray[i])) / deltaY; //S pixel
                     parallelSlope += Math.Abs((pixelArray[j + 1] - pixelArray[i])) / deltaXY; //SE pixel
 
-                    vertexColors[i] = getColorForSlope((ushort)(parallelSlope * 12.5)); // Divide by 8 multiply by 100 => 12.5
+                    vertexColors[i] = GetColorForSlope((ushort)(parallelSlope * 12.5)); // Divide by 8 multiply by 100 => 12.5
                 }
             });
 

--- a/SandWorm/SandWormComponent.cs
+++ b/SandWorm/SandWormComponent.cs
@@ -251,12 +251,13 @@ namespace SandWorm
                         trimmedWidth, trimmedHeight, depthPixelSize.x, depthPixelSize.y);
                     break;
                 case Analytics.Aspect analysis:
-                    // TODO: implementation
+                    vertexColors = analysis.GetColorCloudForAnalysis(averagedDepthFrameData,
+                        trimmedWidth, trimmedHeight);
                     break;
                 default:
                     break;
             }
-    Core.LogTiming(ref output, timer, "Point cloud analysis"); // Debug Info
+            Core.LogTiming(ref output, timer, "Point cloud analysis"); // Debug Info
             
             // Keep only the desired amount of frames in the buffer
             while (renderBuffer.Count >= averageFrames)
@@ -264,7 +265,7 @@ namespace SandWorm
                 renderBuffer.RemoveFirst();
             }
 
-quadMesh = Core.CreateQuadMesh(quadMesh, pointCloud, vertexColors, trimmedWidth, trimmedHeight);
+            quadMesh = Core.CreateQuadMesh(quadMesh, pointCloud, vertexColors, trimmedWidth, trimmedHeight);
             if (keepFrames > 1)
                 outputMesh.Insert(0, quadMesh.DuplicateMesh()); // Clone and prepend if keeping frames
             else
@@ -294,7 +295,7 @@ quadMesh = Core.CreateQuadMesh(quadMesh, pointCloud, vertexColors, trimmedWidth,
             if (keepFrames > 1 && keepFrames<outputMesh.Count)
             {
                 int framesToRemove = outputMesh.Count - keepFrames;
-outputMesh.RemoveRange(keepFrames, framesToRemove > 0 ? framesToRemove : 0);
+                outputMesh.RemoveRange(keepFrames, framesToRemove > 0 ? framesToRemove : 0);
             }
 
             DA.SetDataList(0, outputMesh);


### PR DESCRIPTION
Ok, this all should be good to review. I normally dislike using a full hue spectrum for aspect, so have gone with a pink vs blue and light vs dark. It's not great, but I've run out of ideas for now.

![Annotation 2019-10-17 201600](https://user-images.githubusercontent.com/495961/66996018-a7045200-f11b-11e9-9d4b-30de2428b0b3.png)

The procedure used to process the pixels follows the same structure set out in `Slope.cs`. The aspect value is determined by measuring the difference between the y axis and a per-pixel vector. That vector's `X` and `Y` values derive from the differences in elevation across each of those axes. I.E. if the East pixel is at z = 10 and the West pixel is at z = 30 that X value is 20. In the case of the diagonal axes the values get halved and added to both X and Y.

The above method was developed partly as an effort to avoid assembling and averaging a bunch of normals for each face given the grid spacing is regular. No idea if this is the usual approach, but it seems to work.