### PR TITLE
Add analytics to documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,3 +40,5 @@ aux_links:
 
 # Footer content appears at the bottom of every page's main content
 footer_content: "TODO: Copyright & license details"
+
+ga_tracking: UA-314178-32


### PR DESCRIPTION
This adds Google analytics to the documentation. It would be nice to get a sense of if the docs are used and where it is popular. If that works, I can add you to the account. Alternately, feel free to setup things on your end and substitute the UA id.