### PR TITLE
Update debug method to use Rhino7 and to activate on valid build target

### DIFF
--- a/SandWorm/SandWorm.csproj
+++ b/SandWorm/SandWorm.csproj
@@ -256,8 +256,8 @@
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
     <StartArguments>
     </StartArguments>
     <StartAction>Program</StartAction>


### PR DESCRIPTION
Not sure if you noticed this - but out of the box Sandworm wouldn't let me debug with the normal 'startup Rhino and attach' workflow. The issue is that the Kinect dependencies only compile for x86/64 rather than the generic `Any CPU` target (as far as I can tell).

This updates the `StartProgram` action to trigger on compiling to the `x64` target and updates the application path to Rhino 7 as well. That got things working on my end. Maybe on your end this was handled with uncommited settings?