### PR TITLE
Rework colormaps and add new options (closes #19)

### DIFF
--- a/SandWorm/Analysis.cs
+++ b/SandWorm/Analysis.cs
@@ -64,8 +64,10 @@ namespace SandWorm
             public MeshColorAnalysis(string menuName) : base(menuName, true)
             {
             } // Note: is mutually exclusive
-            
-            public abstract void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange);
+
+            // Provide two methods for overloading; one for custom-gradient-using options and one for the others
+            public virtual void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange) { return; }
+            public virtual void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange, int paletteOptions = 0) { return; } 
 
             public void ComputeLinearRanges(params VisualisationRangeWithColor[] lookUpRanges)
             {

--- a/SandWorm/Analytics/ColorPalettes.cs
+++ b/SandWorm/Analytics/ColorPalettes.cs
@@ -73,6 +73,24 @@ namespace SandWorm
                     colorPalettes[3] = Color.FromArgb(255, 145, 0);
                     colorPalettes[4] = Color.FromArgb(255, 0, 0);
                     break;
+
+                case Structs.ColorPalettes.Turbo:
+                    colorPalettes[0] = Color.FromArgb(48, 18, 59);
+                    colorPalettes[1] = Color.FromArgb(65, 69, 171);
+                    colorPalettes[2] = Color.FromArgb(70,117,237);
+                    colorPalettes[3] = Color.FromArgb(57, 162, 252);
+                    colorPalettes[4] = Color.FromArgb(27, 207, 212);
+                    colorPalettes[5] = Color.FromArgb(36, 236, 166);
+                    colorPalettes[6] = Color.FromArgb(97, 252, 108);
+                    colorPalettes[7] = Color.FromArgb(164, 252, 59);
+                    colorPalettes[8] = Color.FromArgb(209, 232, 52);
+                    colorPalettes[9] = Color.FromArgb(243, 198, 58);
+                    colorPalettes[10] = Color.FromArgb(254, 155, 45);
+                    colorPalettes[11] = Color.FromArgb(243, 99, 21);
+                    colorPalettes[12] = Color.FromArgb(217, 56, 6);
+                    colorPalettes[13] = Color.FromArgb(177, 25, 1);
+                    colorPalettes[14] = Color.FromArgb(122, 4, 2);
+                    break;
             }
 
             return colorPalettes;

--- a/SandWorm/Analytics/ColorPalettes.cs
+++ b/SandWorm/Analytics/ColorPalettes.cs
@@ -5,91 +5,93 @@ namespace SandWorm
 {
     public static class ColorPalettes
     {
-        public static Color[] GenerateColorPalettes(Structs.ColorPalettes palette, List<Color> customColors)
+        public static List<Color> GenerateColorPalettes(Structs.ColorPalettes palette, List<Color> customColors)
         {
-            Color[] paletteSwatches = new Color[20]; // Arbitrary upper limit
+            List<Color> paletteSwatches = new List<Color>();
 
             switch (palette)
             {
                 case Structs.ColorPalettes.Custom:
-                    if (customColors.Count == 0)
-                        break;
-                    for (int i = 0; i < paletteSwatches.Length; i++)
-                        paletteSwatches[i] = customColors[i];
+                    if (customColors.Count == 0) // No inputs provided; use placeholder
+                        paletteSwatches.Add(Color.FromArgb(122, 122, 122));
+                        paletteSwatches.Add(Color.FromArgb(122, 122, 122));
+
+                    for (int i = 0; i < customColors.Count; i++)
+                        paletteSwatches.Add(customColors[i]);
                     break;
 
                 case Structs.ColorPalettes.Chile:
-                    paletteSwatches[0] = Color.FromArgb(38, 115, 0);
-                    paletteSwatches[1] = Color.FromArgb(124, 191, 48);
-                    paletteSwatches[2] = Color.FromArgb(255, 247, 52);
-                    paletteSwatches[3] = Color.FromArgb(196, 65, 0);
-                    paletteSwatches[4] = Color.FromArgb(230, 188, 167);
+                    paletteSwatches.Add(Color.FromArgb(38, 115, 0));
+                    paletteSwatches.Add(Color.FromArgb(124, 191, 48));
+                    paletteSwatches.Add(Color.FromArgb(255, 247, 52));
+                    paletteSwatches.Add(Color.FromArgb(196, 65, 0));
+                    paletteSwatches.Add(Color.FromArgb(230, 188, 167));
                     break;
 
                 case Structs.ColorPalettes.Desert:
-                    paletteSwatches[0] = Color.FromArgb(55, 101, 84);
-                    paletteSwatches[1] = Color.FromArgb(73, 117, 100);
-                    paletteSwatches[2] = Color.FromArgb(172, 196, 160);
-                    paletteSwatches[3] = Color.FromArgb(148, 131, 85);
-                    paletteSwatches[4] = Color.FromArgb(217, 209, 190);
+                    paletteSwatches.Add(Color.FromArgb(55, 101, 84));
+                    paletteSwatches.Add(Color.FromArgb(73, 117, 100));
+                    paletteSwatches.Add(Color.FromArgb(172, 196, 160));
+                    paletteSwatches.Add(Color.FromArgb(148, 131, 85));
+                    paletteSwatches.Add(Color.FromArgb(217, 209, 190));
                     break;
 
                 case Structs.ColorPalettes.Europe:
-                    paletteSwatches[0] = Color.FromArgb(36, 121, 36);
-                    paletteSwatches[1] = Color.FromArgb(89, 148, 54);
-                    paletteSwatches[2] = Color.FromArgb(181, 195, 80);
-                    paletteSwatches[3] = Color.FromArgb(208, 191, 94);
-                    paletteSwatches[4] = Color.FromArgb(115, 24, 19);
+                    paletteSwatches.Add(Color.FromArgb(36, 121, 36));
+                    paletteSwatches.Add(Color.FromArgb(89, 148, 54));
+                    paletteSwatches.Add(Color.FromArgb(181, 195, 80));
+                    paletteSwatches.Add(Color.FromArgb(208, 191, 94));
+                    paletteSwatches.Add(Color.FromArgb(115, 24, 19));
                     break;
 
                 case Structs.ColorPalettes.Greyscale:
-                    paletteSwatches[0] = Color.FromArgb(40, 40, 40);
-                    paletteSwatches[1] = Color.FromArgb(80, 80, 80);
-                    paletteSwatches[2] = Color.FromArgb(120, 120, 120);
-                    paletteSwatches[3] = Color.FromArgb(160, 160, 160);
-                    paletteSwatches[4] = Color.FromArgb(200, 200, 200);
+                    paletteSwatches.Add(Color.FromArgb(40, 40, 40));
+                    paletteSwatches.Add(Color.FromArgb(80, 80, 80));
+                    paletteSwatches.Add(Color.FromArgb(120, 120, 120));
+                    paletteSwatches.Add(Color.FromArgb(160, 160, 160));
+                    paletteSwatches.Add(Color.FromArgb(200, 200, 200));
                     break;
 
                 case Structs.ColorPalettes.Dune:
-                    paletteSwatches[0] = Color.FromArgb(80, 80, 80);
-                    paletteSwatches[1] = Color.FromArgb(122, 91, 76);
-                    paletteSwatches[2] = Color.FromArgb(191, 118, 40);
-                    paletteSwatches[3] = Color.FromArgb(240, 173, 50);
-                    paletteSwatches[4] = Color.FromArgb(255, 210, 128);
+                    paletteSwatches.Add(Color.FromArgb(80, 80, 80));
+                    paletteSwatches.Add(Color.FromArgb(122, 91, 76));
+                    paletteSwatches.Add(Color.FromArgb(191, 118, 40));
+                    paletteSwatches.Add(Color.FromArgb(240, 173, 50));
+                    paletteSwatches.Add(Color.FromArgb(255, 210, 128));
                     break;
 
                 case Structs.ColorPalettes.Ocean:
-                    paletteSwatches[0] = Color.FromArgb(47, 34, 58);
-                    paletteSwatches[1] = Color.FromArgb(62, 90, 146);
-                    paletteSwatches[2] = Color.FromArgb(80, 162, 162);
-                    paletteSwatches[3] = Color.FromArgb(152, 218, 164);
-                    paletteSwatches[4] = Color.FromArgb(250, 250, 200);
+                    paletteSwatches.Add(Color.FromArgb(47, 34, 58));
+                    paletteSwatches.Add(Color.FromArgb(62, 90, 146));
+                    paletteSwatches.Add(Color.FromArgb(80, 162, 162));
+                    paletteSwatches.Add(Color.FromArgb(152, 218, 164));
+                    paletteSwatches.Add(Color.FromArgb(250, 250, 200));
                     break;
 
                 case Structs.ColorPalettes.Rainbow:
-                    paletteSwatches[0] = Color.FromArgb(0, 0, 255);
-                    paletteSwatches[1] = Color.FromArgb(0, 220, 255);
-                    paletteSwatches[2] = Color.FromArgb(140, 255, 110);
-                    paletteSwatches[3] = Color.FromArgb(255, 145, 0);
-                    paletteSwatches[4] = Color.FromArgb(255, 0, 0);
+                    paletteSwatches.Add(Color.FromArgb(0, 0, 255));
+                    paletteSwatches.Add(Color.FromArgb(0, 220, 255));
+                    paletteSwatches.Add(Color.FromArgb(140, 255, 110));
+                    paletteSwatches.Add(Color.FromArgb(255, 145, 0));
+                    paletteSwatches.Add(Color.FromArgb(255, 0, 0));
                     break;
 
                 case Structs.ColorPalettes.Turbo:
-                    paletteSwatches[0] = Color.FromArgb(48, 18, 59);
-                    paletteSwatches[1] = Color.FromArgb(65, 69, 171);
-                    paletteSwatches[2] = Color.FromArgb(70,117,237);
-                    paletteSwatches[3] = Color.FromArgb(57, 162, 252);
-                    paletteSwatches[4] = Color.FromArgb(27, 207, 212);
-                    paletteSwatches[5] = Color.FromArgb(36, 236, 166);
-                    paletteSwatches[6] = Color.FromArgb(97, 252, 108);
-                    paletteSwatches[7] = Color.FromArgb(164, 252, 59);
-                    paletteSwatches[8] = Color.FromArgb(209, 232, 52);
-                    paletteSwatches[9] = Color.FromArgb(243, 198, 58);
-                    paletteSwatches[10] = Color.FromArgb(254, 155, 45);
-                    paletteSwatches[11] = Color.FromArgb(243, 99, 21);
-                    paletteSwatches[12] = Color.FromArgb(217, 56, 6);
-                    paletteSwatches[13] = Color.FromArgb(177, 25, 1);
-                    paletteSwatches[14] = Color.FromArgb(122, 4, 2);
+                    paletteSwatches.Add(Color.FromArgb(48, 18, 59));
+                    paletteSwatches.Add(Color.FromArgb(65, 69, 171));
+                    paletteSwatches.Add(Color.FromArgb(70,117,237));
+                    paletteSwatches.Add(Color.FromArgb(57, 162, 252));
+                    paletteSwatches.Add(Color.FromArgb(27, 207, 212));
+                    paletteSwatches.Add(Color.FromArgb(36, 236, 166));
+                    paletteSwatches.Add(Color.FromArgb(97, 252, 108));
+                    paletteSwatches.Add(Color.FromArgb(164, 252, 59));
+                    paletteSwatches.Add(Color.FromArgb(209, 232, 52));
+                    paletteSwatches.Add(Color.FromArgb(243, 198, 58));
+                    paletteSwatches.Add(Color.FromArgb(254, 155, 45));
+                    paletteSwatches.Add(Color.FromArgb(243, 99, 21));
+                    paletteSwatches.Add(Color.FromArgb(217, 56, 6));
+                    paletteSwatches.Add(Color.FromArgb(177, 25, 1));
+                    paletteSwatches.Add(Color.FromArgb(122, 4, 2));
                     break;
             }
 

--- a/SandWorm/Analytics/ColorPalettes.cs
+++ b/SandWorm/Analytics/ColorPalettes.cs
@@ -7,93 +7,93 @@ namespace SandWorm
     {
         public static Color[] GenerateColorPalettes(Structs.ColorPalettes palette, List<Color> customColors)
         {
-            Color[] colorPalettes = new Color[5];
+            Color[] paletteSwatches = new Color[20]; // Arbitrary upper limit
 
             switch (palette)
             {
                 case Structs.ColorPalettes.Custom:
                     if (customColors.Count == 0)
                         break;
-                    for (int i = 0; i < colorPalettes.Length; i++)
-                        colorPalettes[i] = customColors[i];
+                    for (int i = 0; i < paletteSwatches.Length; i++)
+                        paletteSwatches[i] = customColors[i];
                     break;
 
                 case Structs.ColorPalettes.Chile:
-                    colorPalettes[0] = Color.FromArgb(38, 115, 0);
-                    colorPalettes[1] = Color.FromArgb(124, 191, 48);
-                    colorPalettes[2] = Color.FromArgb(255, 247, 52);
-                    colorPalettes[3] = Color.FromArgb(196, 65, 0);
-                    colorPalettes[4] = Color.FromArgb(230, 188, 167);
+                    paletteSwatches[0] = Color.FromArgb(38, 115, 0);
+                    paletteSwatches[1] = Color.FromArgb(124, 191, 48);
+                    paletteSwatches[2] = Color.FromArgb(255, 247, 52);
+                    paletteSwatches[3] = Color.FromArgb(196, 65, 0);
+                    paletteSwatches[4] = Color.FromArgb(230, 188, 167);
                     break;
 
                 case Structs.ColorPalettes.Desert:
-                    colorPalettes[0] = Color.FromArgb(55, 101, 84);
-                    colorPalettes[1] = Color.FromArgb(73, 117, 100);
-                    colorPalettes[2] = Color.FromArgb(172, 196, 160);
-                    colorPalettes[3] = Color.FromArgb(148, 131, 85);
-                    colorPalettes[4] = Color.FromArgb(217, 209, 190);
+                    paletteSwatches[0] = Color.FromArgb(55, 101, 84);
+                    paletteSwatches[1] = Color.FromArgb(73, 117, 100);
+                    paletteSwatches[2] = Color.FromArgb(172, 196, 160);
+                    paletteSwatches[3] = Color.FromArgb(148, 131, 85);
+                    paletteSwatches[4] = Color.FromArgb(217, 209, 190);
                     break;
 
                 case Structs.ColorPalettes.Europe:
-                    colorPalettes[0] = Color.FromArgb(36, 121, 36);
-                    colorPalettes[1] = Color.FromArgb(89, 148, 54);
-                    colorPalettes[2] = Color.FromArgb(181, 195, 80);
-                    colorPalettes[3] = Color.FromArgb(208, 191, 94);
-                    colorPalettes[4] = Color.FromArgb(115, 24, 19);
+                    paletteSwatches[0] = Color.FromArgb(36, 121, 36);
+                    paletteSwatches[1] = Color.FromArgb(89, 148, 54);
+                    paletteSwatches[2] = Color.FromArgb(181, 195, 80);
+                    paletteSwatches[3] = Color.FromArgb(208, 191, 94);
+                    paletteSwatches[4] = Color.FromArgb(115, 24, 19);
                     break;
 
                 case Structs.ColorPalettes.Greyscale:
-                    colorPalettes[0] = Color.FromArgb(40, 40, 40);
-                    colorPalettes[1] = Color.FromArgb(80, 80, 80);
-                    colorPalettes[2] = Color.FromArgb(120, 120, 120);
-                    colorPalettes[3] = Color.FromArgb(160, 160, 160);
-                    colorPalettes[4] = Color.FromArgb(200, 200, 200);
+                    paletteSwatches[0] = Color.FromArgb(40, 40, 40);
+                    paletteSwatches[1] = Color.FromArgb(80, 80, 80);
+                    paletteSwatches[2] = Color.FromArgb(120, 120, 120);
+                    paletteSwatches[3] = Color.FromArgb(160, 160, 160);
+                    paletteSwatches[4] = Color.FromArgb(200, 200, 200);
                     break;
 
                 case Structs.ColorPalettes.Dune:
-                    colorPalettes[0] = Color.FromArgb(80, 80, 80);
-                    colorPalettes[1] = Color.FromArgb(122, 91, 76);
-                    colorPalettes[2] = Color.FromArgb(191, 118, 40);
-                    colorPalettes[3] = Color.FromArgb(240, 173, 50);
-                    colorPalettes[4] = Color.FromArgb(255, 210, 128);
+                    paletteSwatches[0] = Color.FromArgb(80, 80, 80);
+                    paletteSwatches[1] = Color.FromArgb(122, 91, 76);
+                    paletteSwatches[2] = Color.FromArgb(191, 118, 40);
+                    paletteSwatches[3] = Color.FromArgb(240, 173, 50);
+                    paletteSwatches[4] = Color.FromArgb(255, 210, 128);
                     break;
 
                 case Structs.ColorPalettes.Ocean:
-                    colorPalettes[0] = Color.FromArgb(47, 34, 58);
-                    colorPalettes[1] = Color.FromArgb(62, 90, 146);
-                    colorPalettes[2] = Color.FromArgb(80, 162, 162);
-                    colorPalettes[3] = Color.FromArgb(152, 218, 164);
-                    colorPalettes[4] = Color.FromArgb(250, 250, 200);
+                    paletteSwatches[0] = Color.FromArgb(47, 34, 58);
+                    paletteSwatches[1] = Color.FromArgb(62, 90, 146);
+                    paletteSwatches[2] = Color.FromArgb(80, 162, 162);
+                    paletteSwatches[3] = Color.FromArgb(152, 218, 164);
+                    paletteSwatches[4] = Color.FromArgb(250, 250, 200);
                     break;
 
                 case Structs.ColorPalettes.Rainbow:
-                    colorPalettes[0] = Color.FromArgb(0, 0, 255);
-                    colorPalettes[1] = Color.FromArgb(0, 220, 255);
-                    colorPalettes[2] = Color.FromArgb(140, 255, 110);
-                    colorPalettes[3] = Color.FromArgb(255, 145, 0);
-                    colorPalettes[4] = Color.FromArgb(255, 0, 0);
+                    paletteSwatches[0] = Color.FromArgb(0, 0, 255);
+                    paletteSwatches[1] = Color.FromArgb(0, 220, 255);
+                    paletteSwatches[2] = Color.FromArgb(140, 255, 110);
+                    paletteSwatches[3] = Color.FromArgb(255, 145, 0);
+                    paletteSwatches[4] = Color.FromArgb(255, 0, 0);
                     break;
 
                 case Structs.ColorPalettes.Turbo:
-                    colorPalettes[0] = Color.FromArgb(48, 18, 59);
-                    colorPalettes[1] = Color.FromArgb(65, 69, 171);
-                    colorPalettes[2] = Color.FromArgb(70,117,237);
-                    colorPalettes[3] = Color.FromArgb(57, 162, 252);
-                    colorPalettes[4] = Color.FromArgb(27, 207, 212);
-                    colorPalettes[5] = Color.FromArgb(36, 236, 166);
-                    colorPalettes[6] = Color.FromArgb(97, 252, 108);
-                    colorPalettes[7] = Color.FromArgb(164, 252, 59);
-                    colorPalettes[8] = Color.FromArgb(209, 232, 52);
-                    colorPalettes[9] = Color.FromArgb(243, 198, 58);
-                    colorPalettes[10] = Color.FromArgb(254, 155, 45);
-                    colorPalettes[11] = Color.FromArgb(243, 99, 21);
-                    colorPalettes[12] = Color.FromArgb(217, 56, 6);
-                    colorPalettes[13] = Color.FromArgb(177, 25, 1);
-                    colorPalettes[14] = Color.FromArgb(122, 4, 2);
+                    paletteSwatches[0] = Color.FromArgb(48, 18, 59);
+                    paletteSwatches[1] = Color.FromArgb(65, 69, 171);
+                    paletteSwatches[2] = Color.FromArgb(70,117,237);
+                    paletteSwatches[3] = Color.FromArgb(57, 162, 252);
+                    paletteSwatches[4] = Color.FromArgb(27, 207, 212);
+                    paletteSwatches[5] = Color.FromArgb(36, 236, 166);
+                    paletteSwatches[6] = Color.FromArgb(97, 252, 108);
+                    paletteSwatches[7] = Color.FromArgb(164, 252, 59);
+                    paletteSwatches[8] = Color.FromArgb(209, 232, 52);
+                    paletteSwatches[9] = Color.FromArgb(243, 198, 58);
+                    paletteSwatches[10] = Color.FromArgb(254, 155, 45);
+                    paletteSwatches[11] = Color.FromArgb(243, 99, 21);
+                    paletteSwatches[12] = Color.FromArgb(217, 56, 6);
+                    paletteSwatches[13] = Color.FromArgb(177, 25, 1);
+                    paletteSwatches[14] = Color.FromArgb(122, 4, 2);
                     break;
             }
 
-            return colorPalettes;
+            return paletteSwatches;
         }
     }
 }

--- a/SandWorm/Analytics/ColorPalettes.cs
+++ b/SandWorm/Analytics/ColorPalettes.cs
@@ -68,14 +68,6 @@ namespace SandWorm
                     paletteSwatches.Add(Color.FromArgb(250, 250, 200));
                     break;
 
-                case Structs.ColorPalettes.Rainbow:
-                    paletteSwatches.Add(Color.FromArgb(0, 0, 255));
-                    paletteSwatches.Add(Color.FromArgb(0, 220, 255));
-                    paletteSwatches.Add(Color.FromArgb(140, 255, 110));
-                    paletteSwatches.Add(Color.FromArgb(255, 145, 0));
-                    paletteSwatches.Add(Color.FromArgb(255, 0, 0));
-                    break;
-
                 case Structs.ColorPalettes.Turbo:
                     paletteSwatches.Add(Color.FromArgb(48, 18, 59));
                     paletteSwatches.Add(Color.FromArgb(65, 69, 171));
@@ -92,6 +84,29 @@ namespace SandWorm
                     paletteSwatches.Add(Color.FromArgb(217, 56, 6));
                     paletteSwatches.Add(Color.FromArgb(177, 25, 1));
                     paletteSwatches.Add(Color.FromArgb(122, 4, 2));
+                    break;
+
+                case Structs.ColorPalettes.Viridis:
+                    paletteSwatches.Add(Color.FromArgb(52, 0, 66));
+                    paletteSwatches.Add(Color.FromArgb(55, 8, 85));
+                    paletteSwatches.Add(Color.FromArgb(55, 23, 100));
+                    paletteSwatches.Add(Color.FromArgb(53, 37, 110));
+                    paletteSwatches.Add(Color.FromArgb(48, 52, 117));
+                    paletteSwatches.Add(Color.FromArgb(44, 65, 121));
+                    paletteSwatches.Add(Color.FromArgb(39, 80, 123));
+                    paletteSwatches.Add(Color.FromArgb(36, 93, 123));
+                    paletteSwatches.Add(Color.FromArgb(33, 106, 123));
+                    paletteSwatches.Add(Color.FromArgb(31, 120, 122));
+                    paletteSwatches.Add(Color.FromArgb(30, 134, 120));
+                    paletteSwatches.Add(Color.FromArgb(32, 148, 115));
+                    paletteSwatches.Add(Color.FromArgb(38, 162, 108));
+                    paletteSwatches.Add(Color.FromArgb(52, 178, 98));
+                    paletteSwatches.Add(Color.FromArgb(73, 190, 84));
+                    paletteSwatches.Add(Color.FromArgb(101, 202, 68));
+                    paletteSwatches.Add(Color.FromArgb(132, 212, 50));
+                    paletteSwatches.Add(Color.FromArgb(171, 219, 32));
+                    paletteSwatches.Add(Color.FromArgb(212, 225, 21));
+                    paletteSwatches.Add(Color.FromArgb(252, 229, 30));
                     break;
             }
 

--- a/SandWorm/Analytics/Elevation.cs
+++ b/SandWorm/Analytics/Elevation.cs
@@ -9,7 +9,7 @@ namespace SandWorm.Analytics
         private int _lastSensorElevation; // Keep track of prior values to recalculate only as needed
         private double _lastGradientRange;
         private Structs.ColorPalettes _colorPalette = Structs.ColorPalettes.Europe;
-        Color[] paletteSwatches; // Color values for the given palette
+        List<Color> paletteSwatches; // Color values for the given palette
 
         public Elevation() : base("Visualise Elevation")
         {
@@ -23,7 +23,7 @@ namespace SandWorm.Analytics
             if (lookupTable == null || sensorElevationRounded != _lastSensorElevation || gradientRange != _lastGradientRange)
             {
                 paletteSwatches = ColorPalettes.GenerateColorPalettes(_colorPalette, customColors);
-                ComputeLookupTableForAnalysis(sensorElevation, gradientRange, paletteSwatches.Length);
+                ComputeLookupTableForAnalysis(sensorElevation, gradientRange, paletteSwatches.Count);
             }
 
             // Lookup elevation value in color table
@@ -44,8 +44,8 @@ namespace SandWorm.Analytics
         // Given the sensor's height from the table, map between vertical distance intervals and color palette values
         public override void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange, int swatchCount)
         {
-            var elevationRanges = new Analysis.VisualisationRangeWithColor[swatchCount];
-            for (int i = 0; i < swatchCount; i++)
+            var elevationRanges = new Analysis.VisualisationRangeWithColor[swatchCount - 1];
+            for (int i = 0; i < swatchCount - 1; i++)
             {
                 var elevationRange = new Analysis.VisualisationRangeWithColor
                 {

--- a/SandWorm/Analytics/None.cs
+++ b/SandWorm/Analytics/None.cs
@@ -14,10 +14,5 @@ namespace SandWorm.Analytics
             var vertexColors = new Color[0];
             return vertexColors; // Send back an empty array so mesh is transparent/uncolored
         }
-
-        public override void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange)
-        {
-            return; // No lookup table necessary
-        }
     }
 }

--- a/SandWorm/Analytics/RGB.cs
+++ b/SandWorm/Analytics/RGB.cs
@@ -19,10 +19,5 @@ namespace SandWorm.Analytics
             
             return vertexColors; 
         }
-
-        public override void ComputeLookupTableForAnalysis(double sensorElevation, double gradientRange)
-        {
-            return; // No lookup table necessary
-        }
     }
 }

--- a/SandWorm/SandWorm.csproj
+++ b/SandWorm/SandWorm.csproj
@@ -256,8 +256,8 @@
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
     <StartArguments>
     </StartArguments>
     <StartAction>Program</StartAction>

--- a/SandWorm/Utilities/Structs.cs
+++ b/SandWorm/Utilities/Structs.cs
@@ -35,7 +35,8 @@ namespace SandWorm
             Europe,
             Greyscale,
             Ocean,
-            Rainbow
+            Rainbow,
+            Turbo
         }
     }
 }

--- a/SandWorm/Utilities/Structs.cs
+++ b/SandWorm/Utilities/Structs.cs
@@ -35,8 +35,8 @@ namespace SandWorm
             Europe,
             Greyscale,
             Ocean,
-            Rainbow,
-            Turbo
+            Turbo,
+            Viridis
         }
     }
 }


### PR DESCRIPTION
These commits:

- Rework the lookup table generation so the palette libraries don't need to be a fixed length
- Adds the Viridis palette option (another perceptually-uniform option; pictured below)
- Replaces Rainbow with Turbo (although in practice they were very similar)

![viridis](https://user-images.githubusercontent.com/495961/130000220-a19eed5b-ecbe-41e6-8b05-b4c074d7ae5e.jpg)
