### PR TITLE
Misc fixes for state serialisation

### DIFF
--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -274,8 +274,9 @@ namespace SandWorm
             
             if (_labelSpacing.Value > 0 && ((AnalysisTypes) _analysisType.Value == AnalysisTypes.CutFill || (AnalysisTypes)_analysisType.Value == AnalysisTypes.Elevation))
             {
-                foreach (var text in labels)
-                    args.Display.Draw3dText(text, Color.White);
+                if (labels != null)
+                    foreach (var text in labels)
+                        args.Display.Draw3dText(text, Color.White);
             }
         }
 

--- a/SandWorm/CustomComponent/MenuCheckBox.cs
+++ b/SandWorm/CustomComponent/MenuCheckBox.cs
@@ -87,7 +87,8 @@ public class MenuCheckBox : GH_Attr_Widget
 	public override bool Read(GH_IReader reader)
 	{
 		GH_IReader gH_IReader = reader.FindChunk("Checkbox", Index);
-		_active = gH_IReader.GetBoolean("Active");
+		if (gH_IReader != null)
+			_active = gH_IReader.GetBoolean("Active");
 		return true;
 	}
 

--- a/SandWorm/CustomComponent/MenuSlider.cs
+++ b/SandWorm/CustomComponent/MenuSlider.cs
@@ -221,13 +221,18 @@ namespace SandWorm
         public override bool Read(GH_IReader reader)
         {
             GH_IReader gH_IReader = reader.FindChunk("Slider", Index);
-            minValue = gH_IReader.GetDouble("MinValue");
-            maxValue = gH_IReader.GetDouble("MaxValue");
-            currentValue = gH_IReader.GetDouble("CurrentValue");
-            if (!gH_IReader.TryGetInt32("NumDecimals", ref numDecimals))
+            if (gH_IReader != null)
             {
-                numDecimals = 2;
+                minValue = gH_IReader.GetDouble("MinValue");
+                maxValue = gH_IReader.GetDouble("MaxValue");
+                currentValue = gH_IReader.GetDouble("CurrentValue");
+
+                if (!gH_IReader.TryGetInt32("NumDecimals", ref numDecimals))
+                {
+                    numDecimals = 2;
+                }
             }
+
             FixValues();
             return true;
         }


### PR DESCRIPTION
I came across a couple of errors when loading a previously saved file that relate from the lack of previously-saved state. While I imagine that the keys used to serialise the data will be pretty consistent from here on out, it may be worth catching those errors regardless.