### PR TITLE
Change 'neutral' cut and fill colour so contours/labels will show

### DIFF
--- a/SandWorm/Analytics/ColorPalettes.cs
+++ b/SandWorm/Analytics/ColorPalettes.cs
@@ -32,7 +32,7 @@ namespace SandWorm
 
                 case Structs.ColorPalettes.CutFill:
                     paletteSwatches.Add(Color.FromArgb(235, 100, 75));
-                    paletteSwatches.Add(Color.FromArgb(255, 255, 255));
+                    paletteSwatches.Add(Color.FromArgb(40, 40, 40));
                     paletteSwatches.Add(Color.FromArgb(164, 206, 101));
                     break;
 

--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -269,13 +269,16 @@ namespace SandWorm
             if (_cloud != null)
                 args.Display.DrawPointCloud(_cloud, 3);
 
+            var grayscaled = (int)(_labelBrightness.Value * 12.75); // 0-20 into 0-255
+            var labelAndContourColor = Color.FromArgb(grayscaled, grayscaled, grayscaled);
+
             if (_outputContours != null && _outputContours.Count != 0 && Params.Output[2].Recipients.Count == 0)
-                args.Display.DrawLines(_outputContours, Color.White, 1);
+                args.Display.DrawLines(_outputContours, labelAndContourColor, 1);
             
             if (_labelSpacing.Value > 0 && ((AnalysisTypes) _analysisType.Value == AnalysisTypes.CutFill || (AnalysisTypes)_analysisType.Value == AnalysisTypes.Elevation))
             {
                 foreach (var text in labels)
-                    args.Display.Draw3dText(text, Color.White);
+                    args.Display.Draw3dText(text, labelAndContourColor);
             }
         }
 

--- a/SandWorm/ComponentsUI/SandWormComponentUI.cs
+++ b/SandWorm/ComponentsUI/SandWormComponentUI.cs
@@ -26,6 +26,7 @@ namespace SandWorm
         public static MenuSlider _contourRoughness;
         public static MenuSlider _waterLevel;
         public static MenuSlider _labelSpacing;
+        public static MenuSlider _labelBrightness;
 
         public static MenuSlider _averagedFrames;
         public static MenuSlider _blurRadius;
@@ -140,6 +141,9 @@ namespace SandWorm
             _labelSpacing = new MenuSlider(labelSpacingHeader, 241, 0, 100, 20, 0);
             _labelSpacing.Step = 5;
 
+            MenuStaticText labelBrightnessHeader = new MenuStaticText("Label brightness", "Defines the colour of labels and contours, going from white to black.");
+            _labelBrightness = new MenuSlider(labelBrightnessHeader, 242, 0, 20, 20, 0);
+
             MenuStaticText contourIntervalHeader = new MenuStaticText("Contour interval", "Define spacing between contours. \nInput should be in millimeters.");
             _contourIntervalRange = new MenuSlider(contourIntervalHeader, 25, 0, 30, 0, 0);
 
@@ -163,6 +167,8 @@ namespace SandWorm
             analysisPanel.AddControl(_colorGradientRange);
             analysisPanel.AddControl(labelSpacingHeader);
             analysisPanel.AddControl(_labelSpacing);
+            analysisPanel.AddControl(labelBrightnessHeader);
+            analysisPanel.AddControl(_labelBrightness);
             analysisPanel.AddControl(contourIntervalHeader);
             analysisPanel.AddControl(_contourIntervalRange);
             analysisPanel.AddControl(contourRoughnessHeader);


### PR DESCRIPTION
Suggestion: as both the labels and contours are white (and themes developed around this?) they get lost in the cut/fill mode where a large portion of the model might be in the 'neutral' state - particularly if you're only position a few items in it rather than a 1:1 copy of the mesh with the same bounds. Shifting that colour to black might be more usable?

![ViewCapture20210829_183248](https://user-images.githubusercontent.com/495961/131244203-b1b3a1cf-1fd0-432f-8155-50e16fb54ba1.jpg)