### PR TITLE
Output volume stats as clean ints so they can be more easily used dow…

### DIFF
--- a/SandWorm/Analytics/CutFill.cs
+++ b/SandWorm/Analytics/CutFill.cs
@@ -67,9 +67,12 @@ namespace SandWorm.Analytics
                 }
             }
             
-            stats.Add($"Cut: {System.Math.Round(_cut * 0.001)} cubic centimeters");
-            stats.Add($"Fill: {System.Math.Round(_fill * 0.001)} cubic centimeters");
-            stats.Add($"Cut/Fill Balance: {System.Math.Round((_cut + _fill) * 0.001)} cubic centimeters");
+            stats.Add($"Cut Volume, in cubic centimeters:");
+            stats.Add(System.Math.Round(_cut * 0.001).ToString());
+            stats.Add($"Fill Volume, in cubic centimeters:");
+            stats.Add(System.Math.Round(_fill * 0.001).ToString());
+            stats.Add($"Cut/Fill Balance, in cubic centimeters:");
+            stats.Add(System.Math.Round((_cut + _fill) * 0.001).ToString());
             return vertexColors;
         }
 


### PR DESCRIPTION
For my purposes, it would be useful to take the cut/fill figures and use them to make graphs with Human UI and to trigger a 'success' state when the balanced volume is within a certain range. While string substitution is possible in Grasshopper, it's a royal pain so it would be great if the stats output put 'clean' numbers that could be easily plucked using `List Item` and used downstream. The other slight benefit is that this more easily differentiates the timing logs from the analysis outputs.