### PR TITLE
Feature/#81 dpi scaling

### DIFF
--- a/SandWorm/CustomComponent/WidgetServer.cs
+++ b/SandWorm/CustomComponent/WidgetServer.cs
@@ -74,29 +74,30 @@ namespace SandWorm
             float num = Screen.PrimaryScreen.LogicalPixelSize;
             if ((double)num > 0.95 && (double)num < 1.05)
             {
-                num = 1f;
+                num = 1f; // Windows scaling % as int; e.g. 200% = 2.0
             }
             return num;
         }
 
         public static int ScaleFontSize(int font_size)
         {
+            // E.g. 8em at 100% scale; 4em at 200% scale
             return (int)Math.Round((double)font_size * (double)GH_FontServer.StandardAdjusted.Height / (double)GH_FontServer.Standard.Height);
         }
 
         private WidgetServer()
         {
             string name = "Arial";
-            int num = 8;
+            int num = ScaleFontSize(8);
             TextFont = new Font(new FontFamily(name), num, FontStyle.Regular);
             string name2 = "Arial";
-            int num2 = 8;
+            int num2 = ScaleFontSize(8);
             DropdownFont = new Font(new FontFamily(name2), num2, FontStyle.Italic);
             string name3 = "Arial";
-            int num3 = 8;
+            int num3 = ScaleFontSize(8);
             MenuHeaderFont = new Font(new FontFamily(name3), num3, FontStyle.Bold);
             string name4 = "Arial";
-            int num4 = 10;
+            int num4 = ScaleFontSize(10);
             SliderValueTagFont = new Font(new FontFamily(name4), num4, FontStyle.Italic);
             int width = 8;
             int height = 8;


### PR DESCRIPTION
Continuing on from #81, the existing DPI scaling functions in `WidgetServer` seem to have the correct logic; they just needed to be referenced for the main font types. I've only tested this on one machine thus far, but dropdown and other custom UI fonts seem to respond appropriately across a range of different scaling %s.