### PR TITLE
Fix color palette failure in certain scenarios

### DIFF
--- a/SandWorm/Analytics/Elevation.cs
+++ b/SandWorm/Analytics/Elevation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.Collections.Generic;
 using Rhino.Display;
+using System;
 
 namespace SandWorm.Analytics
 {
@@ -49,7 +50,7 @@ namespace SandWorm.Analytics
             {
                 var elevationRange = new Analysis.VisualisationRangeWithColor
                 {
-                    ValueSpan = (int)(gradientRange / swatchCount),
+                    ValueSpan = Math.Max((int)(gradientRange / swatchCount), 1), // Prevent 0 value
                     ColorStart = new ColorHSL(paletteSwatches[i]),
                     ColorEnd = new ColorHSL(paletteSwatches[i+1])
                 };


### PR DESCRIPTION
In cases where the size of `swatchCount` exceeds that of `gradientRange`, the `ValueSpan` of a colour theme can then become 0. When computing linear ranges, the `progress` calculation will then fail with a Not a Number error. This only seemed to crop up when using *Viridis* with a particularly wide set of possible elevations.