### PR TITLE
Increase permitted Sensor elevation value

### DIFF
--- a/SandWorm/ComponentsUI/SandWormComponentUI.cs
+++ b/SandWorm/ComponentsUI/SandWormComponentUI.cs
@@ -73,7 +73,7 @@ namespace SandWorm
             _calibrate = new MenuButton(111121, "Calibrate Elevation"); // "Initiate the automatic calibration process to determine elevation."
  
             MenuStaticText sensorElevationHeader = new MenuStaticText("Sensor elevation", "Distance between the sensor and the table. \nInput should be in millimeters.\nTo automatically estimate this value, check the 'Calibrate' checkbox and reset.");
-            _sensorElevation = new MenuSlider(sensorElevationHeader, 1, 0, 1500, 1000, 0);
+            _sensorElevation = new MenuSlider(sensorElevationHeader, 1, 0, 2000, 1000, 0);
 
             MenuStaticText leftColumnsHeader = new MenuStaticText("Left columns", "Number of pixels to trim from the left.");
             _leftColumns = new MenuSlider(leftColumnsHeader, 2, 0, 200, 50, 0);


### PR DESCRIPTION
I'm back working on a Kinect for Windows due to a somewhat flaky USB port on the Azure. I ended up needing a bit more range in the *Sensor elevation* to align the bottom of the table to `z=0`. Hopefully expanding the possible range of values here is worth the slight loss in precision dragging.