### PR TITLE
Add keyboard shortcut control

### DIFF
--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -406,54 +406,57 @@ namespace SandWorm
         {
             switch (e.KeyCode)
             {
-                case Keys.F10:
+                case Keys.F13:
                     _analysisType.Value = (int)Structs.AnalysisTypes.None;
                     break;
 
-                case Keys.F11:
+                case Keys.F14:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Camera;
                     break;
 
-                case Keys.F12:
+                case Keys.F15:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Elevation;
                     break;
 
-                case Keys.F13:
+                case Keys.F16:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Slope;
                     break;
 
-                case Keys.F14:
+                case Keys.F17:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Aspect;
                     break;
 
-                case Keys.F15:
+                case Keys.F18:
                     _analysisType.Value = (int)Structs.AnalysisTypes.CutFill;
                     break;
 
-                case Keys.F16: // Toggle contours on or off.
+                case Keys.F19: // Toggle contours on or off.
                     if (_contourIntervalRange.Value == 0)
                         _contourIntervalRange.Value = 25; // TODO: store last value so toggle isn't destructive?
                     else
                         _contourIntervalRange.Value = 0; 
                     break;
 
-                case Keys.F17: // Toggle water plane on or off. 
+                case Keys.F20: // Toggle water plane on or off. 
                     if (_waterLevel.Value == 0)
                         _waterLevel.Value = 1; // TODO: store last value so toggle isn't destructive?
                     else
                         _waterLevel.Value = 0; 
                     break;
 
-                case Keys.F18: // Toggle flood sim on or off
+                case Keys.F21: // Toggle flood sim on or off
                     _simulateFloodEvent.Active = !_simulateFloodEvent.Active;
                     break;
 
-                case Keys.F19: // Toggle flood sim on or off
+                case Keys.F22: // Toggle flood sim on or off
                     _makeItRain.Active = !_makeItRain.Active;
                     break;
 
-                case Keys.F20: // Reset
+                case Keys.F23: // Reset
                     reset = true;
+                    break;
+
+                case Keys.F24: // Unused
                     break;
 
                 default:

--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -5,17 +5,17 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Numerics;
+using System.Windows.Forms;
 
 using Rhino;
 using Rhino.Geometry;
-
 using Grasshopper.Kernel;
+using Microsoft.Azure.Kinect.Sensor;
 
 using SandWorm.Analytics;
 using static SandWorm.Core;
 using static SandWorm.Structs;
 using static SandWorm.SandWormComponentUI;
-using Microsoft.Azure.Kinect.Sensor;
 
 namespace SandWorm
 {
@@ -366,6 +366,8 @@ namespace SandWorm
         public override Guid ComponentGuid => new Guid("{53fefb98-1cec-4134-b707-0c366072af2c}");
         public override void AddedToDocument(GH_Document document)
         {
+            Grasshopper.Instances.DocumentEditor.KeyDown += new KeyEventHandler(SandwormShortcutHandler);
+
             if (Params.Input[0].SourceCount == 0)
             {
                 List<IGH_DocumentObject> componentList = new List<IGH_DocumentObject>();
@@ -399,6 +401,66 @@ namespace SandWorm
         {
             ExpireSolution(false);
         }
+
+        private void SandwormShortcutHandler(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.F10:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.None;
+                    break;
+
+                case Keys.F11:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.Camera;
+                    break;
+
+                case Keys.F12:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.Elevation;
+                    break;
+
+                case Keys.F13:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.Slope;
+                    break;
+
+                case Keys.F14:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.Aspect;
+                    break;
+
+                case Keys.F15:
+                    _analysisType.Value = (int)Structs.AnalysisTypes.CutFill;
+                    break;
+
+                case Keys.F16: // Toggle contours on or off.
+                    if (_contourIntervalRange.Value == 0)
+                        _contourIntervalRange.Value = 25; // TODO: store last value so toggle isn't destructive?
+                    else
+                        _contourIntervalRange.Value = 0; 
+                    break;
+
+                case Keys.F17: // Toggle water plane on or off. 
+                    if (_waterLevel.Value == 0)
+                        _waterLevel.Value = 1; // TODO: store last value so toggle isn't destructive?
+                    else
+                        _waterLevel.Value = 0; 
+                    break;
+
+                case Keys.F18: // Toggle flood sim on or off
+                    _simulateFloodEvent.Active = !_simulateFloodEvent.Active;
+                    break;
+
+                case Keys.F19: // Toggle flood sim on or off
+                    _makeItRain.Active = !_makeItRain.Active;
+                    break;
+
+                case Keys.F20: // Reset
+                    reset = true;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
         private void ResetDataArrays()
         {
             quadMesh = null;

--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -63,6 +63,10 @@ namespace SandWorm
         private ConcurrentDictionary<int, FlowLine> flowLines;
         Color[] waterColors = null;
 
+        // Temporary storage of prior values for hotkey toggling
+        public double _lastContourInterval;
+        public double _lastWaterLevel;
+
         // Outputs
         private List<GeometryBase> _outputWaterSurface;
         private List<Line> _outputContours;
@@ -103,6 +107,8 @@ namespace SandWorm
         protected override void Setup(GH_ExtendableComponentAttributes attr) // Initialize the UI
         {
             MainComponentUI(attr);
+            _lastContourInterval = _contourIntervalRange.Value;
+            _lastWaterLevel = _waterLevel.Value;
         }
 
         protected override void OnComponentLoaded()
@@ -432,31 +438,41 @@ namespace SandWorm
 
                 case Keys.F19: // Toggle contours on or off.
                     if (_contourIntervalRange.Value == 0)
-                        _contourIntervalRange.Value = 25; // TODO: store last value so toggle isn't destructive?
+                    {
+                        _contourIntervalRange.Value = _lastContourInterval;
+                    }
                     else
-                        _contourIntervalRange.Value = 0; 
+                    {
+                        _lastContourInterval = _contourIntervalRange.Value;
+                        _contourIntervalRange.Value = 0;
+                    }
                     break;
 
                 case Keys.F20: // Toggle water plane on or off. 
                     if (_waterLevel.Value == 0)
-                        _waterLevel.Value = 1; // TODO: store last value so toggle isn't destructive?
+                    {
+                        _waterLevel.Value = _lastWaterLevel; 
+                    }
                     else
-                        _waterLevel.Value = 0; 
+                    {
+                        _lastWaterLevel = _waterLevel.Value;
+                        _waterLevel.Value = 0;
+                    }
                     break;
 
-                case Keys.F21: // Toggle flood sim on or off
+                case Keys.F21: // Toggle flood sim 
                     _simulateFloodEvent.Active = !_simulateFloodEvent.Active;
                     break;
 
-                case Keys.F22: // Toggle flood sim on or off
+                case Keys.F22: // Toggle flow sim
                     _makeItRain.Active = !_makeItRain.Active;
                     break;
 
-                case Keys.F23: // Reset
+                case Keys.F23: // Reset camera
                     reset = true;
                     break;
 
-                case Keys.F24: // Unused
+                case Keys.F24: // Reserved for future use
                     break;
 
                 default:

--- a/SandWorm/Components/SandWormComponent.cs
+++ b/SandWorm/Components/SandWormComponent.cs
@@ -64,6 +64,9 @@ namespace SandWorm
         Color[] waterColors = null;
 
         // Temporary storage of prior values for hotkey toggling
+        public Dictionary<int, DateTime> _lastPressForKey = new Dictionary<int, DateTime>() {
+            { (int)Keys.ShiftKey, DateTime.Now } 
+        };
         public double _lastContourInterval;
         public double _lastWaterLevel;
 
@@ -372,7 +375,8 @@ namespace SandWorm
         public override Guid ComponentGuid => new Guid("{53fefb98-1cec-4134-b707-0c366072af2c}");
         public override void AddedToDocument(GH_Document document)
         {
-            Grasshopper.Instances.DocumentEditor.KeyDown += new KeyEventHandler(SandwormShortcutHandler);
+            Rhino.RhinoApp.KeyboardEvent -= new Rhino.RhinoApp.KeyboardHookEvent(SandwormShortcutHandler);
+            Rhino.RhinoApp.KeyboardEvent += new Rhino.RhinoApp.KeyboardHookEvent(SandwormShortcutHandler);
 
             if (Params.Input[0].SourceCount == 0)
             {
@@ -408,35 +412,65 @@ namespace SandWorm
             ExpireSolution(false);
         }
 
-        private void SandwormShortcutHandler(object sender, KeyEventArgs e)
+        private void SandwormShortcutHandler(int keyIndex)
         {
-            switch (e.KeyCode)
+            if (keyIndex == (int)Keys.ShiftKey)
             {
-                case Keys.F13:
+                _lastPressForKey[(int)Keys.ShiftKey] = DateTime.Now; // Track last SHIFT press to enable chord shortcuts
+                return;  // Don't process SHIFT-activations on their own
+            }
+
+            // This handler has no access to events, so need to track time since last key event manually (to enable deduplication)
+            if (_lastPressForKey.ContainsKey(keyIndex)) 
+            {
+                TimeSpan timeSinceLastPress = DateTime.Now - _lastPressForKey[keyIndex];
+                if (timeSinceLastPress.TotalMilliseconds < 300) // Repeats must be 0.3s or more apart
+                {
+                    return; // Prevent retriggers within short time frames (e.g. keydown > keypress > keyrepeat > keyup)
+                }
+            }
+
+            TimeSpan timeSinceShiftModifier = DateTime.Now - _lastPressForKey[(int)Keys.ShiftKey];
+            if (timeSinceShiftModifier.TotalMilliseconds > 2000) // 2 seconds to activate F-key after SHIFT engaged
+            {
+                return; // Only activate F1-12 keys if SHIFT is used as a modifier chord
+            }
+
+            _lastPressForKey[keyIndex] = DateTime.Now; // Track activate for debouncing
+
+            switch (keyIndex)
+            {
+                case (int)Keys.F2: // Start here as shift+F1 is an accessibility shortcut
                     _analysisType.Value = (int)Structs.AnalysisTypes.None;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to deactivate any analysis.");
                     break;
 
-                case Keys.F14:
+                case (int)Keys.F3:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Camera;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to analyse the camera feed.");
                     break;
 
-                case Keys.F15:
+                case (int)Keys.F4:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Elevation;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to analyse elevation.");
                     break;
 
-                case Keys.F16:
+                case (int)Keys.F5:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Slope;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to analyse slope.");
                     break;
 
-                case Keys.F17:
+                case (int)Keys.F6:
                     _analysisType.Value = (int)Structs.AnalysisTypes.Aspect;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to analyse aspect.");
                     break;
 
-                case Keys.F18:
+                case (int)Keys.F7:
                     _analysisType.Value = (int)Structs.AnalysisTypes.CutFill;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to analyse cut/fill.");
                     break;
 
-                case Keys.F19: // Toggle contours on or off.
+                case (int)Keys.F8: // Toggle contours on or off.
                     if (_contourIntervalRange.Value == 0)
                     {
                         _contourIntervalRange.Value = _lastContourInterval;
@@ -446,9 +480,10 @@ namespace SandWorm
                         _lastContourInterval = _contourIntervalRange.Value;
                         _contourIntervalRange.Value = 0;
                     }
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to toggle contours.");
                     break;
 
-                case Keys.F20: // Toggle water plane on or off. 
+                case (int)Keys.F9: // Toggle water plane on or off. 
                     if (_waterLevel.Value == 0)
                     {
                         _waterLevel.Value = _lastWaterLevel; 
@@ -458,21 +493,22 @@ namespace SandWorm
                         _lastWaterLevel = _waterLevel.Value;
                         _waterLevel.Value = 0;
                     }
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to toggle water plane.");
                     break;
 
-                case Keys.F21: // Toggle flood sim 
+                case (int)Keys.F10: // Toggle flood sim 
                     _simulateFloodEvent.Active = !_simulateFloodEvent.Active;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to toggle flood simulation.");
                     break;
 
-                case Keys.F22: // Toggle flow sim
+                case (int)Keys.F11: // Toggle flow sim
                     _makeItRain.Active = !_makeItRain.Active;
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to toggle flow simulation.");
                     break;
 
-                case Keys.F23: // Reset camera
+                case (int)Keys.F12: // Reset camera
                     reset = true;
-                    break;
-
-                case Keys.F24: // Reserved for future use
+                    Rhino.RhinoApp.WriteLine("Activating Sandworm " + (Keys)keyIndex + " shortcut to reset camera.");
                     break;
 
                 default:


### PR DESCRIPTION
This is a quick prototype / RFC for adding keyboard shortcuts to control common options in the component UI. The use case here is both ease of access and a better ability to run things 'headless' - e.g. with the controlling computer more out of the way. 

In my case I have a small numpad I'd imagined for this purpose, and might consider something like a StreamDeck for exhibition-like contexts. The keys on either of those options can be remapped to whatever, so the use of F10-F20 below is relatively arbitrary and could be made to be either more intuitive or more obscure.

If this is of value, the todo list is:

- [x] Check `FXX` hotkeys are actually free and not conflicting with anything
- [x] Update UI state once values change
- [ ] Shift the code out of the main SandwormComponent?
- [x] Extend `MenuSlider` to store the 'last non-zero value' so that, e.g. toggling contours on/off will not always reset to a hardcoded value